### PR TITLE
chore(parser): add spec-compliant GraphQL Error struct

### DIFF
--- a/bluejay-parser/Cargo.toml
+++ b/bluejay-parser/Cargo.toml
@@ -13,6 +13,7 @@ description = "A GraphQL parser"
 logos = { version = "0.14" }
 enum-as-inner = "0.6"
 ariadne = { version = "0.4.1" }
+serde = { version = "1.0.203", optional = true }
 bluejay-core = { version = "0.1.0", path = "../bluejay-core" }
 strum = { version = "0.26", features = ["derive"] }
 
@@ -27,6 +28,7 @@ harness = false
 
 [features]
 format-errors = []
+serde = ["dep:serde"]
 
 [lints]
 workspace = true

--- a/bluejay-parser/Cargo.toml
+++ b/bluejay-parser/Cargo.toml
@@ -12,7 +12,7 @@ description = "A GraphQL parser"
 [dependencies]
 logos = { version = "0.14" }
 enum-as-inner = "0.6"
-ariadne = { version = "0.4.1", optional = true }
+ariadne = { version = "0.4.1" }
 bluejay-core = { version = "0.1.0", path = "../bluejay-core" }
 strum = { version = "0.26", features = ["derive"] }
 
@@ -26,7 +26,7 @@ name = "parse_github_schema"
 harness = false
 
 [features]
-format-errors = ["dep:ariadne"]
+format-errors = []
 
 [lints]
 workspace = true

--- a/bluejay-parser/src/error.rs
+++ b/bluejay-parser/src/error.rs
@@ -1,5 +1,6 @@
-#[cfg(feature = "format-errors")]
 use ariadne::{Config, IndexType, Label, Report, ReportKind, Source};
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
 use std::borrow::Cow;
 
 mod annotation;
@@ -16,6 +17,7 @@ pub struct Error {
 }
 
 #[derive(Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 pub struct Location {
     pub line: usize,
     pub col: usize,
@@ -23,6 +25,7 @@ pub struct Location {
 
 /// A [spec compliant GraphQL Error](https://spec.graphql.org/draft/#sec-Errors.Error-Result-Format)
 #[derive(Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 pub struct GraphQLError {
     pub message: Cow<'static, str>,
     pub locations: Vec<Location>,

--- a/bluejay-parser/src/error.rs
+++ b/bluejay-parser/src/error.rs
@@ -53,28 +53,28 @@ impl Error {
             .into_iter()
             .flat_map(|err| {
                 let err: Error = err.into();
-                if let Some(ref primary_annotation) = err.primary_annotation {
+                if let Some(primary_annotation) = err.primary_annotation {
                     let (line, col) = converter
                         .convert(primary_annotation.span())
                         .unwrap_or((0, 0));
-                    return vec![GraphQLError {
-                        message: primary_annotation.message.clone(),
+                    vec![GraphQLError {
+                        message: primary_annotation.message,
                         locations: vec![Location { line, col }],
-                    }];
+                    }]
+                } else {
+                    err.secondary_annotations
+                        .into_iter()
+                        .map(|secondary_annotation| {
+                            let (line, col) = converter
+                                .convert(secondary_annotation.span())
+                                .unwrap_or((0, 0));
+                            GraphQLError {
+                                message: secondary_annotation.message,
+                                locations: vec![Location { line, col }],
+                            }
+                        })
+                        .collect()
                 }
-
-                err.secondary_annotations
-                    .iter()
-                    .map(|secondary_annotation| {
-                        let (line, col) = converter
-                            .convert(secondary_annotation.span())
-                            .unwrap_or((0, 0));
-                        GraphQLError {
-                            message: secondary_annotation.message.clone(),
-                            locations: vec![Location { line, col }],
-                        }
-                    })
-                    .collect()
             })
             .collect()
     }

--- a/bluejay-parser/tests/graphql_parse_errors.rs
+++ b/bluejay-parser/tests/graphql_parse_errors.rs
@@ -1,3 +1,5 @@
+use std::borrow::Cow;
+
 use bluejay_parser::{
     ast::{executable::ExecutableDocument, Parse},
     error::{GraphQLError, Location},
@@ -12,12 +14,11 @@ fn test_parser_errors() {
     let document = ExecutableDocument::parse(source);
 
     assert!(document.is_err());
-    if let Err(document_errors) = document {
-        let graphql_errors = Error::into_graphql_error(source, document_errors);
-        let expected: Vec<GraphQLError> = vec![GraphQLError {
-            message: "Parse error".to_string(),
-            locations: vec![Location { line: 2, col: 15 }],
-        }];
-        assert_eq!(expected, graphql_errors);
-    }
+    let document_errors = document.unwrap_err();
+    let graphql_errors = Error::into_graphql_errors(source, document_errors);
+    let expected: Vec<GraphQLError> = vec![GraphQLError {
+        message: Cow::from("Expected a name"),
+        locations: vec![Location { line: 2, col: 15 }],
+    }];
+    assert_eq!(expected, graphql_errors);
 }

--- a/bluejay-parser/tests/graphql_parse_errors.rs
+++ b/bluejay-parser/tests/graphql_parse_errors.rs
@@ -1,0 +1,23 @@
+use bluejay_parser::{
+    ast::{executable::ExecutableDocument, Parse},
+    error::{GraphQLError, Location},
+    Error,
+};
+
+#[test]
+fn test_parser_errors() {
+    let source = r#"{
+        field()
+    }"#;
+    let document = ExecutableDocument::parse(source);
+
+    assert!(document.is_err());
+    if let Err(document_errors) = document {
+        let graphql_errors = Error::into_graphql_error(source, document_errors);
+        let expected: Vec<GraphQLError> = vec![GraphQLError {
+            message: "Parse error".to_string(),
+            locations: vec![Location { line: 2, col: 15 }],
+        }];
+        assert_eq!(expected, graphql_errors);
+    }
+}


### PR DESCRIPTION
Currently we offer no way of deriving a [spec-compliant GraphQL error](https://spec.graphql.org/draft/#sec-Errors.Error-Result-Format) from i.e. a parsing error. This adds that functionality, currently it does not yet include `path` as that is impossible during parse time.

Currently this can be used by doing

```rust
Error::into_graphql_errors(source, document_errors)
```

Some questions

- do we keep the `format-errors` feature around and add a `graphql-errors` feature?
- do we implement some serialize/deserialize traits form serde for this?

It does seem so that in the [GraphQL.JS](https://github.com/graphql/graphql-js/blob/main/src/error/syntaxError.ts#L9-L18) reference implementation we talk about a `SyntaxError` here. As we are in the `parser` I assume it would be safe for us to also brand this as `syntax-error` rather than `graphql-error`?