### PR TITLE
Make executable document directives an Option

### DIFF
--- a/bluejay-core/src/executable/field.rs
+++ b/bluejay-core/src/executable/field.rs
@@ -9,7 +9,7 @@ pub trait Field {
     fn alias(&self) -> Option<&str>;
     fn name(&self) -> &str;
     fn arguments(&self) -> Option<&Self::Arguments>;
-    fn directives(&self) -> &Self::Directives;
+    fn directives(&self) -> Option<&Self::Directives>;
     fn selection_set(&self) -> Option<&Self::SelectionSet>;
 
     fn response_name(&self) -> &str {

--- a/bluejay-core/src/executable/fragment_definition.rs
+++ b/bluejay-core/src/executable/fragment_definition.rs
@@ -7,6 +7,6 @@ pub trait FragmentDefinition: Indexable {
 
     fn name(&self) -> &str;
     fn type_condition(&self) -> &str;
-    fn directives(&self) -> &Self::Directives;
+    fn directives(&self) -> Option<&Self::Directives>;
     fn selection_set(&self) -> &Self::SelectionSet;
 }

--- a/bluejay-core/src/executable/fragment_spread.rs
+++ b/bluejay-core/src/executable/fragment_spread.rs
@@ -4,5 +4,5 @@ pub trait FragmentSpread {
     type Directives: VariableDirectives;
 
     fn name(&self) -> &str;
-    fn directives(&self) -> &Self::Directives;
+    fn directives(&self) -> Option<&Self::Directives>;
 }

--- a/bluejay-core/src/executable/inline_fragment.rs
+++ b/bluejay-core/src/executable/inline_fragment.rs
@@ -6,6 +6,6 @@ pub trait InlineFragment {
     type SelectionSet: SelectionSet;
 
     fn type_condition(&self) -> Option<&str>;
-    fn directives(&self) -> &Self::Directives;
+    fn directives(&self) -> Option<&Self::Directives>;
     fn selection_set(&self) -> &Self::SelectionSet;
 }

--- a/bluejay-core/src/executable/operation_definition.rs
+++ b/bluejay-core/src/executable/operation_definition.rs
@@ -38,7 +38,7 @@ impl<'a, O: OperationDefinition> OperationDefinitionReference<'a, O> {
 
     pub fn directives(&self) -> Option<&'a <<O as OperationDefinition>::ExplicitOperationDefinition as ExplicitOperationDefinition>::Directives>{
         match self {
-            Self::Explicit(eod) => Some(eod.directives()),
+            Self::Explicit(eod) => eod.directives(),
             Self::Implicit(_) => None,
         }
     }
@@ -59,7 +59,7 @@ pub trait ExplicitOperationDefinition {
     fn operation_type(&self) -> OperationType;
     fn name(&self) -> Option<&str>;
     fn variable_definitions(&self) -> Option<&Self::VariableDefinitions>;
-    fn directives(&self) -> &Self::Directives;
+    fn directives(&self) -> Option<&Self::Directives>;
     fn selection_set(&self) -> &Self::SelectionSet;
 }
 

--- a/bluejay-core/src/executable/selection.rs
+++ b/bluejay-core/src/executable/selection.rs
@@ -16,7 +16,7 @@ pub trait Selection: Sized {
 }
 
 impl<'a, S: Selection> SelectionReference<'a, S> {
-    pub fn directives(&self) -> &'a <S::Field as Field>::Directives {
+    pub fn directives(&self) -> Option<&'a <S::Field as Field>::Directives> {
         match self {
             Self::Field(f) => f.directives(),
             Self::FragmentSpread(fs) => fs.directives(),

--- a/bluejay-core/src/executable/variable_definition.rs
+++ b/bluejay-core/src/executable/variable_definition.rs
@@ -8,7 +8,7 @@ pub trait VariableDefinition {
 
     fn variable(&self) -> &str;
     fn r#type(&self) -> &Self::VariableType;
-    fn directives(&self) -> &Self::Directives;
+    fn directives(&self) -> Option<&Self::Directives>;
     fn default_value(&self) -> Option<&Self::Value>;
 
     fn is_required(&self) -> bool {

--- a/bluejay-parser/src/ast/executable/field.rs
+++ b/bluejay-parser/src/ast/executable/field.rs
@@ -48,7 +48,11 @@ impl<'a> FromTokens<'a> for Field<'a> {
             alias,
             name,
             arguments,
-            directives: if directives.len() > 0 { Some(directives) } else { None },
+            directives: if directives.len() > 0 {
+                Some(directives)
+            } else {
+                None
+            },
             selection_set,
             span,
         })

--- a/bluejay-parser/src/ast/executable/field.rs
+++ b/bluejay-parser/src/ast/executable/field.rs
@@ -1,3 +1,5 @@
+use bluejay_core::AsIter;
+
 use crate::ast::executable::SelectionSet;
 use crate::ast::{
     FromTokens, IsMatch, ParseError, Tokens, TryFromTokens, VariableArguments, VariableDirectives,
@@ -12,7 +14,7 @@ pub struct Field<'a> {
     alias: Option<Name<'a>>,
     name: Name<'a>,
     arguments: Option<VariableArguments<'a>>,
-    directives: VariableDirectives<'a>,
+    directives: Option<VariableDirectives<'a>>,
     selection_set: Option<SelectionSet<'a>>,
     span: Span,
 }
@@ -46,7 +48,7 @@ impl<'a> FromTokens<'a> for Field<'a> {
             alias,
             name,
             arguments,
-            directives,
+            directives: if directives.len() > 0 { Some(directives) } else { None },
             selection_set,
             span,
         })
@@ -98,8 +100,8 @@ impl<'a> bluejay_core::executable::Field for Field<'a> {
         self.arguments.as_ref()
     }
 
-    fn directives(&self) -> &Self::Directives {
-        &self.directives
+    fn directives(&self) -> Option<&Self::Directives> {
+        self.directives.as_ref()
     }
 
     fn selection_set(&self) -> Option<&Self::SelectionSet> {

--- a/bluejay-parser/src/ast/executable/fragment_definition.rs
+++ b/bluejay-parser/src/ast/executable/fragment_definition.rs
@@ -1,3 +1,5 @@
+use bluejay_core::AsIter;
+
 use crate::ast::executable::{SelectionSet, TypeCondition};
 use crate::ast::{FromTokens, IsMatch, ParseError, Tokens, VariableDirectives};
 use crate::lexical_token::Name;
@@ -7,7 +9,7 @@ use crate::{HasSpan, Span};
 pub struct FragmentDefinition<'a> {
     name: Name<'a>,
     type_condition: TypeCondition<'a>,
-    directives: VariableDirectives<'a>,
+    directives: Option<VariableDirectives<'a>>,
     selection_set: SelectionSet<'a>,
     span: Span,
 }
@@ -33,7 +35,7 @@ impl<'a> FromTokens<'a> for FragmentDefinition<'a> {
         Ok(Self {
             name,
             type_condition,
-            directives,
+            directives: if directives.len() > 0 { Some(directives) } else { None },
             selection_set,
             span,
         })
@@ -74,8 +76,8 @@ impl<'a> bluejay_core::executable::FragmentDefinition for FragmentDefinition<'a>
         self.type_condition.named_type().as_ref()
     }
 
-    fn directives(&self) -> &Self::Directives {
-        &self.directives
+    fn directives(&self) -> Option<&Self::Directives> {
+        self.directives.as_ref()
     }
 
     fn selection_set(&self) -> &Self::SelectionSet {

--- a/bluejay-parser/src/ast/executable/fragment_definition.rs
+++ b/bluejay-parser/src/ast/executable/fragment_definition.rs
@@ -35,7 +35,11 @@ impl<'a> FromTokens<'a> for FragmentDefinition<'a> {
         Ok(Self {
             name,
             type_condition,
-            directives: if directives.len() > 0 { Some(directives) } else { None },
+            directives: if directives.len() > 0 {
+                Some(directives)
+            } else {
+                None
+            },
             selection_set,
             span,
         })

--- a/bluejay-parser/src/ast/executable/fragment_definition.rs
+++ b/bluejay-parser/src/ast/executable/fragment_definition.rs
@@ -1,6 +1,5 @@
-use bluejay_core::AsIter;
-
 use crate::ast::executable::{SelectionSet, TypeCondition};
+use crate::ast::try_from_tokens::TryFromTokens;
 use crate::ast::{FromTokens, IsMatch, ParseError, Tokens, VariableDirectives};
 use crate::lexical_token::Name;
 use crate::{HasSpan, Span};
@@ -29,17 +28,13 @@ impl<'a> FromTokens<'a> for FragmentDefinition<'a> {
             return Err(ParseError::UnexpectedToken { span: name.into() });
         }
         let type_condition = TypeCondition::from_tokens(tokens)?;
-        let directives = VariableDirectives::from_tokens(tokens)?;
+        let directives = VariableDirectives::try_from_tokens(tokens).transpose()?;
         let selection_set = SelectionSet::from_tokens(tokens)?;
         let span = fragment_identifier_span.merge(selection_set.span());
         Ok(Self {
             name,
             type_condition,
-            directives: if directives.len() > 0 {
-                Some(directives)
-            } else {
-                None
-            },
+            directives,
             selection_set,
             span,
         })

--- a/bluejay-parser/src/ast/executable/fragment_spread.rs
+++ b/bluejay-parser/src/ast/executable/fragment_spread.rs
@@ -2,11 +2,12 @@ use crate::ast::executable::TypeCondition;
 use crate::ast::{FromTokens, IsMatch, ParseError, Tokens, VariableDirectives};
 use crate::lexical_token::{Name, PunctuatorType};
 use crate::{HasSpan, Span};
+use bluejay_core::AsIter;
 
 #[derive(Debug)]
 pub struct FragmentSpread<'a> {
     name: Name<'a>,
-    directives: VariableDirectives<'a>,
+    directives: Option<VariableDirectives<'a>>,
     span: Span,
 }
 
@@ -19,7 +20,7 @@ impl<'a> FromTokens<'a> for FragmentSpread<'a> {
         let span = ellipse_span.merge(name.span());
         Ok(Self {
             name,
-            directives,
+            directives: if directives.len() > 0 { Some(directives) } else { None },
             span,
         })
     }
@@ -48,8 +49,8 @@ impl<'a> bluejay_core::executable::FragmentSpread for FragmentSpread<'a> {
         self.name.as_ref()
     }
 
-    fn directives(&self) -> &Self::Directives {
-        &self.directives
+    fn directives(&self) -> Option<&Self::Directives> {
+        self.directives.as_ref()
     }
 }
 

--- a/bluejay-parser/src/ast/executable/fragment_spread.rs
+++ b/bluejay-parser/src/ast/executable/fragment_spread.rs
@@ -1,8 +1,8 @@
 use crate::ast::executable::TypeCondition;
+use crate::ast::try_from_tokens::TryFromTokens;
 use crate::ast::{FromTokens, IsMatch, ParseError, Tokens, VariableDirectives};
 use crate::lexical_token::{Name, PunctuatorType};
 use crate::{HasSpan, Span};
-use bluejay_core::AsIter;
 
 #[derive(Debug)]
 pub struct FragmentSpread<'a> {
@@ -16,15 +16,11 @@ impl<'a> FromTokens<'a> for FragmentSpread<'a> {
         let ellipse_span = tokens.expect_punctuator(PunctuatorType::Ellipse)?;
         let name = tokens.expect_name()?;
         assert_ne!(TypeCondition::ON, name.as_ref());
-        let directives = VariableDirectives::from_tokens(tokens)?;
+        let directives = VariableDirectives::try_from_tokens(tokens).transpose()?;
         let span = ellipse_span.merge(name.span());
         Ok(Self {
             name,
-            directives: if directives.len() > 0 {
-                Some(directives)
-            } else {
-                None
-            },
+            directives,
             span,
         })
     }

--- a/bluejay-parser/src/ast/executable/fragment_spread.rs
+++ b/bluejay-parser/src/ast/executable/fragment_spread.rs
@@ -20,7 +20,11 @@ impl<'a> FromTokens<'a> for FragmentSpread<'a> {
         let span = ellipse_span.merge(name.span());
         Ok(Self {
             name,
-            directives: if directives.len() > 0 { Some(directives) } else { None },
+            directives: if directives.len() > 0 {
+                Some(directives)
+            } else {
+                None
+            },
             span,
         })
     }

--- a/bluejay-parser/src/ast/executable/inline_fragment.rs
+++ b/bluejay-parser/src/ast/executable/inline_fragment.rs
@@ -2,7 +2,6 @@ use crate::ast::executable::{SelectionSet, TypeCondition};
 use crate::ast::{FromTokens, IsMatch, ParseError, Tokens, TryFromTokens, VariableDirectives};
 use crate::lexical_token::PunctuatorType;
 use crate::{HasSpan, Span};
-use bluejay_core::AsIter;
 
 #[derive(Debug)]
 pub struct InlineFragment<'a> {
@@ -16,16 +15,12 @@ impl<'a> FromTokens<'a> for InlineFragment<'a> {
     fn from_tokens(tokens: &mut impl Tokens<'a>) -> Result<Self, ParseError> {
         let ellipse_span = tokens.expect_punctuator(PunctuatorType::Ellipse)?;
         let type_condition = TypeCondition::try_from_tokens(tokens).transpose()?;
-        let directives = VariableDirectives::from_tokens(tokens)?;
+        let directives = VariableDirectives::try_from_tokens(tokens).transpose()?;
         let selection_set = SelectionSet::from_tokens(tokens)?;
         let span = ellipse_span.merge(selection_set.span());
         Ok(Self {
             type_condition,
-            directives: if directives.len() > 0 {
-                Some(directives)
-            } else {
-                None
-            },
+            directives,
             selection_set,
             span,
         })

--- a/bluejay-parser/src/ast/executable/inline_fragment.rs
+++ b/bluejay-parser/src/ast/executable/inline_fragment.rs
@@ -21,7 +21,11 @@ impl<'a> FromTokens<'a> for InlineFragment<'a> {
         let span = ellipse_span.merge(selection_set.span());
         Ok(Self {
             type_condition,
-            directives: if directives.len() > 0 { Some(directives) } else { None },
+            directives: if directives.len() > 0 {
+                Some(directives)
+            } else {
+                None
+            },
             selection_set,
             span,
         })

--- a/bluejay-parser/src/ast/executable/inline_fragment.rs
+++ b/bluejay-parser/src/ast/executable/inline_fragment.rs
@@ -2,11 +2,12 @@ use crate::ast::executable::{SelectionSet, TypeCondition};
 use crate::ast::{FromTokens, IsMatch, ParseError, Tokens, TryFromTokens, VariableDirectives};
 use crate::lexical_token::PunctuatorType;
 use crate::{HasSpan, Span};
+use bluejay_core::AsIter;
 
 #[derive(Debug)]
 pub struct InlineFragment<'a> {
     type_condition: Option<TypeCondition<'a>>,
-    directives: VariableDirectives<'a>,
+    directives: Option<VariableDirectives<'a>>,
     selection_set: SelectionSet<'a>,
     span: Span,
 }
@@ -20,7 +21,7 @@ impl<'a> FromTokens<'a> for InlineFragment<'a> {
         let span = ellipse_span.merge(selection_set.span());
         Ok(Self {
             type_condition,
-            directives,
+            directives: if directives.len() > 0 { Some(directives) } else { None },
             selection_set,
             span,
         })
@@ -57,8 +58,8 @@ impl<'a> bluejay_core::executable::InlineFragment for InlineFragment<'a> {
             .map(|tc| tc.named_type().as_ref())
     }
 
-    fn directives(&self) -> &Self::Directives {
-        &self.directives
+    fn directives(&self) -> Option<&Self::Directives> {
+        self.directives.as_ref()
     }
 
     fn selection_set(&self) -> &Self::SelectionSet {

--- a/bluejay-parser/src/ast/executable/operation_definition.rs
+++ b/bluejay-parser/src/ast/executable/operation_definition.rs
@@ -4,7 +4,6 @@ use crate::ast::{
 };
 use crate::lexical_token::Name;
 use crate::{HasSpan, Span};
-use bluejay_core::AsIter;
 use bluejay_core::{
     executable::{OperationDefinition as CoreOperationDefinition, OperationDefinitionReference},
     Indexable,
@@ -50,18 +49,14 @@ impl<'a> FromTokens<'a> for OperationDefinition<'a> {
         if let Some(operation_type) = OperationType::try_from_tokens(tokens).transpose()? {
             let name = tokens.next_if_name();
             let variable_definitions = VariableDefinitions::try_from_tokens(tokens).transpose()?;
-            let directives = VariableDirectives::from_tokens(tokens)?;
+            let directives = VariableDirectives::try_from_tokens(tokens).transpose()?;
             let selection_set = SelectionSet::from_tokens(tokens)?;
             let span = operation_type.span().merge(selection_set.span());
             Ok(Self::Explicit(ExplicitOperationDefinition {
                 operation_type,
                 name,
                 variable_definitions,
-                directives: if directives.len() > 0 {
-                    Some(directives)
-                } else {
-                    None
-                },
+                directives,
                 selection_set,
                 span,
             }))

--- a/bluejay-parser/src/ast/executable/operation_definition.rs
+++ b/bluejay-parser/src/ast/executable/operation_definition.rs
@@ -57,7 +57,11 @@ impl<'a> FromTokens<'a> for OperationDefinition<'a> {
                 operation_type,
                 name,
                 variable_definitions,
-                directives: if directives.len() > 0 { Some(directives) } else { None },
+                directives: if directives.len() > 0 {
+                    Some(directives)
+                } else {
+                    None
+                },
                 selection_set,
                 span,
             }))

--- a/bluejay-parser/src/ast/executable/operation_definition.rs
+++ b/bluejay-parser/src/ast/executable/operation_definition.rs
@@ -4,6 +4,7 @@ use crate::ast::{
 };
 use crate::lexical_token::Name;
 use crate::{HasSpan, Span};
+use bluejay_core::AsIter;
 use bluejay_core::{
     executable::{OperationDefinition as CoreOperationDefinition, OperationDefinitionReference},
     Indexable,
@@ -56,7 +57,7 @@ impl<'a> FromTokens<'a> for OperationDefinition<'a> {
                 operation_type,
                 name,
                 variable_definitions,
-                directives,
+                directives: if directives.len() > 0 { Some(directives) } else { None },
                 selection_set,
                 span,
             }))
@@ -90,7 +91,7 @@ pub struct ExplicitOperationDefinition<'a> {
     operation_type: OperationType,
     name: Option<Name<'a>>,
     variable_definitions: Option<VariableDefinitions<'a>>,
-    directives: VariableDirectives<'a>,
+    directives: Option<VariableDirectives<'a>>,
     selection_set: SelectionSet<'a>,
     span: Span,
 }
@@ -112,8 +113,8 @@ impl<'a> bluejay_core::executable::ExplicitOperationDefinition for ExplicitOpera
         self.variable_definitions.as_ref()
     }
 
-    fn directives(&self) -> &Self::Directives {
-        &self.directives
+    fn directives(&self) -> Option<&Self::Directives> {
+        self.directives.as_ref()
     }
 
     fn selection_set(&self) -> &Self::SelectionSet {

--- a/bluejay-parser/src/ast/executable/variable_definition.rs
+++ b/bluejay-parser/src/ast/executable/variable_definition.rs
@@ -1,5 +1,4 @@
-use bluejay_core::AsIter;
-
+use crate::ast::try_from_tokens::TryFromTokens;
 use crate::ast::{
     executable::VariableType, ConstDirectives, ConstValue, FromTokens, ParseError, Tokens, Variable,
 };
@@ -24,16 +23,12 @@ impl<'a> FromTokens<'a> for VariableDefinition<'a> {
             } else {
                 None
             };
-        let directives = ConstDirectives::from_tokens(tokens)?;
+        let directives = ConstDirectives::try_from_tokens(tokens).transpose()?;
         Ok(Self {
             variable,
             r#type,
             default_value,
-            directives: if directives.len() > 0 {
-                Some(directives)
-            } else {
-                None
-            },
+            directives,
         })
     }
 }

--- a/bluejay-parser/src/ast/executable/variable_definition.rs
+++ b/bluejay-parser/src/ast/executable/variable_definition.rs
@@ -1,3 +1,5 @@
+use bluejay_core::AsIter;
+
 use crate::ast::{
     executable::VariableType, ConstDirectives, ConstValue, FromTokens, ParseError, Tokens, Variable,
 };
@@ -8,7 +10,7 @@ pub struct VariableDefinition<'a> {
     variable: Variable<'a>,
     r#type: VariableType<'a>,
     default_value: Option<ConstValue<'a>>,
-    directives: ConstDirectives<'a>,
+    directives: Option<ConstDirectives<'a>>,
 }
 
 impl<'a> FromTokens<'a> for VariableDefinition<'a> {
@@ -27,7 +29,7 @@ impl<'a> FromTokens<'a> for VariableDefinition<'a> {
             variable,
             r#type,
             default_value,
-            directives,
+            directives: if directives.len() > 0 { Some(directives) } else { None },
         })
     }
 }
@@ -59,8 +61,8 @@ impl<'a> bluejay_core::executable::VariableDefinition for VariableDefinition<'a>
         &self.r#type
     }
 
-    fn directives(&self) -> &Self::Directives {
-        &self.directives
+    fn directives(&self) -> Option<&Self::Directives> {
+        self.directives.as_ref()
     }
 
     fn default_value(&self) -> Option<&Self::Value> {

--- a/bluejay-parser/src/ast/executable/variable_definition.rs
+++ b/bluejay-parser/src/ast/executable/variable_definition.rs
@@ -29,7 +29,11 @@ impl<'a> FromTokens<'a> for VariableDefinition<'a> {
             variable,
             r#type,
             default_value,
-            directives: if directives.len() > 0 { Some(directives) } else { None },
+            directives: if directives.len() > 0 {
+                Some(directives)
+            } else {
+                None
+            },
         })
     }
 }

--- a/bluejay-printer/src/executable/field.rs
+++ b/bluejay-printer/src/executable/field.rs
@@ -27,7 +27,9 @@ impl<'a, F: Field> Display for FieldPrinter<'a, F> {
         if let Some(arguments) = field.arguments() {
             write!(f, "{}", ArgumentsPrinter::new(arguments))?;
         }
-        write!(f, "{}", DirectivesPrinter::new(field.directives()))?;
+        if let Some(directives) = field.directives() {
+            write!(f, "{}", DirectivesPrinter::new(directives))?;
+        }
         if let Some(selection_set) = field.selection_set() {
             write!(
                 f,

--- a/bluejay-printer/src/executable/fragment_spread.rs
+++ b/bluejay-printer/src/executable/fragment_spread.rs
@@ -32,12 +32,7 @@ impl<'a, T: FragmentSpread> Display for FragmentSpreadPrinter<'a, T> {
                 DirectivesPrinter::new(directives)
             )
         } else {
-            write!(
-                f,
-                "...{}",
-                fragment_spread.name(),
-            )
+            write!(f, "...{}", fragment_spread.name(),)
         }
-    
     }
 }

--- a/bluejay-printer/src/executable/fragment_spread.rs
+++ b/bluejay-printer/src/executable/fragment_spread.rs
@@ -24,15 +24,14 @@ impl<'a, T: FragmentSpread> Display for FragmentSpreadPrinter<'a, T> {
             indentation,
         } = *self;
         write_indent(f, indentation)?;
+        write!(f, "...{}", fragment_spread.name())?;
         if let Some(directives) = fragment_spread.directives() {
             write!(
                 f,
-                "...{}{}",
-                fragment_spread.name(),
+                "{}",
                 DirectivesPrinter::new(directives)
-            )
-        } else {
-            write!(f, "...{}", fragment_spread.name(),)
-        }
+            )?;
+        };
+        Ok(())
     }
 }

--- a/bluejay-printer/src/executable/fragment_spread.rs
+++ b/bluejay-printer/src/executable/fragment_spread.rs
@@ -26,11 +26,7 @@ impl<'a, T: FragmentSpread> Display for FragmentSpreadPrinter<'a, T> {
         write_indent(f, indentation)?;
         write!(f, "...{}", fragment_spread.name())?;
         if let Some(directives) = fragment_spread.directives() {
-            write!(
-                f,
-                "{}",
-                DirectivesPrinter::new(directives)
-            )?;
+            write!(f, "{}", DirectivesPrinter::new(directives))?;
         };
         Ok(())
     }

--- a/bluejay-printer/src/executable/fragment_spread.rs
+++ b/bluejay-printer/src/executable/fragment_spread.rs
@@ -24,11 +24,20 @@ impl<'a, T: FragmentSpread> Display for FragmentSpreadPrinter<'a, T> {
             indentation,
         } = *self;
         write_indent(f, indentation)?;
-        write!(
-            f,
-            "...{}{}",
-            fragment_spread.name(),
-            DirectivesPrinter::new(fragment_spread.directives())
-        )
+        if let Some(directives) = fragment_spread.directives() {
+            write!(
+                f,
+                "...{}{}",
+                fragment_spread.name(),
+                DirectivesPrinter::new(directives)
+            )
+        } else {
+            write!(
+                f,
+                "...{}",
+                fragment_spread.name(),
+            )
+        }
+    
     }
 }

--- a/bluejay-printer/src/executable/inline_fragment.rs
+++ b/bluejay-printer/src/executable/inline_fragment.rs
@@ -1,5 +1,5 @@
 use crate::{directive::DirectivesPrinter, executable::SelectionSetPrinter, write_indent};
-use bluejay_core::{executable::InlineFragment, AsIter};
+use bluejay_core::executable::InlineFragment;
 use std::fmt::{Display, Formatter, Result};
 
 pub(crate) struct InlineFragmentPrinter<'a, I: InlineFragment> {
@@ -27,11 +27,11 @@ impl<'a, I: InlineFragment> Display for InlineFragmentPrinter<'a, I> {
         if let Some(type_condition) = inline_fragment.type_condition() {
             write!(f, "on {}", type_condition)?;
         }
-        if !inline_fragment.directives().is_empty() {
+        if let Some(directives) = inline_fragment.directives() {
             write!(
                 f,
                 "{}",
-                DirectivesPrinter::new(inline_fragment.directives())
+                DirectivesPrinter::new(directives)
             )?;
         }
 

--- a/bluejay-printer/src/executable/inline_fragment.rs
+++ b/bluejay-printer/src/executable/inline_fragment.rs
@@ -28,11 +28,7 @@ impl<'a, I: InlineFragment> Display for InlineFragmentPrinter<'a, I> {
             write!(f, "on {}", type_condition)?;
         }
         if let Some(directives) = inline_fragment.directives() {
-            write!(
-                f,
-                "{}",
-                DirectivesPrinter::new(directives)
-            )?;
+            write!(f, "{}", DirectivesPrinter::new(directives))?;
         }
 
         write!(

--- a/bluejay-printer/src/executable/variable_definition.rs
+++ b/bluejay-printer/src/executable/variable_definition.rs
@@ -29,11 +29,15 @@ impl<'a, T: VariableDefinition> Display for VariableDefinitionPrinter<'a, T> {
         if let Some(default_value) = variable_definition.default_value() {
             write!(f, " = {}", ValuePrinter::new(default_value))?;
         }
-        write!(
-            f,
-            "{}",
-            DirectivesPrinter::new(variable_definition.directives())
-        )
+
+        if let Some(directives) =  variable_definition.directives() {
+            write!(
+                f,
+                "{}",
+                DirectivesPrinter::new(directives)
+            )?;
+        };
+        Ok(())
     }
 }
 

--- a/bluejay-printer/src/executable/variable_definition.rs
+++ b/bluejay-printer/src/executable/variable_definition.rs
@@ -30,12 +30,8 @@ impl<'a, T: VariableDefinition> Display for VariableDefinitionPrinter<'a, T> {
             write!(f, " = {}", ValuePrinter::new(default_value))?;
         }
 
-        if let Some(directives) =  variable_definition.directives() {
-            write!(
-                f,
-                "{}",
-                DirectivesPrinter::new(directives)
-            )?;
+        if let Some(directives) = variable_definition.directives() {
+            write!(f, "{}", DirectivesPrinter::new(directives))?;
         };
         Ok(())
     }

--- a/bluejay-validator/src/executable/document/orchestrator.rs
+++ b/bluejay-validator/src/executable/document/orchestrator.rs
@@ -103,11 +103,14 @@ impl<'a, E: ExecutableDocument, S: SchemaDefinition, V: Visitor<'a, E, S>>
         if let Some(type_condition) = type_condition {
             self.visit_selection_set(fragment_definition.selection_set(), type_condition, &path);
         }
-        self.visit_variable_directives(
-            fragment_definition.directives(),
-            DirectiveLocation::FragmentDefinition,
-            &path,
-        );
+        if let Some(directives) = fragment_definition.directives() {
+            self.visit_variable_directives(
+                directives,
+                DirectiveLocation::FragmentDefinition,
+                &path,
+            );
+        }
+
         self.visitor.visit_fragment_definition(fragment_definition);
     }
 
@@ -148,7 +151,13 @@ impl<'a, E: ExecutableDocument, S: SchemaDefinition, V: Visitor<'a, E, S>>
         path: &Path<'a, E>,
     ) {
         self.visitor.visit_field(field, field_definition, path);
-        self.visit_variable_directives(field.directives(), DirectiveLocation::Field, path);
+        if let Some(directives) = field.directives() {
+            self.visit_variable_directives(
+                directives,
+                DirectiveLocation::Field,
+                &path,
+            );
+        }
 
         if let Some((arguments, arguments_definition)) = field
             .arguments()
@@ -231,11 +240,13 @@ impl<'a, E: ExecutableDocument, S: SchemaDefinition, V: Visitor<'a, E, S>>
         scoped_type: TypeDefinitionReference<'a, S::TypeDefinition>,
         path: &Path<'a, E>,
     ) {
-        self.visit_variable_directives(
-            inline_fragment.directives(),
-            DirectiveLocation::InlineFragment,
-            path,
-        );
+        if let Some(directives) = inline_fragment.directives() {
+            self.visit_variable_directives(
+                directives,
+                DirectiveLocation::InlineFragment,
+                &path,
+            );
+        }
 
         let fragment_type = if let Some(type_condition) = inline_fragment.type_condition() {
             self.schema_definition.get_type_definition(type_condition)
@@ -257,11 +268,14 @@ impl<'a, E: ExecutableDocument, S: SchemaDefinition, V: Visitor<'a, E, S>>
         scoped_type: TypeDefinitionReference<'a, S::TypeDefinition>,
         path: &Path<'a, E>,
     ) {
-        self.visit_variable_directives(
-            fragment_spread.directives(),
-            DirectiveLocation::FragmentSpread,
-            path,
-        );
+        if let Some(directives) = fragment_spread.directives() {
+            self.visit_variable_directives(
+                directives,
+                DirectiveLocation::FragmentSpread,
+                &path,
+            );
+        }
+
         self.visitor
             .visit_fragment_spread(fragment_spread, scoped_type, path);
         // fragment will get checked when definition is visited
@@ -271,10 +285,12 @@ impl<'a, E: ExecutableDocument, S: SchemaDefinition, V: Visitor<'a, E, S>>
         self.visitor
             .visit_variable_definitions(variable_definitions);
         variable_definitions.iter().for_each(|variable_definition| {
-            self.visit_const_directives(
-                variable_definition.directives(),
-                DirectiveLocation::VariableDefinition,
-            );
+            if let Some(directives) = variable_definition.directives() {
+                self.visit_const_directives(
+                    directives,
+                    DirectiveLocation::VariableDefinition,
+                );
+            }
             self.visitor.visit_variable_definition(variable_definition);
         });
     }

--- a/bluejay-validator/src/executable/document/orchestrator.rs
+++ b/bluejay-validator/src/executable/document/orchestrator.rs
@@ -152,11 +152,7 @@ impl<'a, E: ExecutableDocument, S: SchemaDefinition, V: Visitor<'a, E, S>>
     ) {
         self.visitor.visit_field(field, field_definition, path);
         if let Some(directives) = field.directives() {
-            self.visit_variable_directives(
-                directives,
-                DirectiveLocation::Field,
-                &path,
-            );
+            self.visit_variable_directives(directives, DirectiveLocation::Field, path);
         }
 
         if let Some((arguments, arguments_definition)) = field
@@ -241,11 +237,7 @@ impl<'a, E: ExecutableDocument, S: SchemaDefinition, V: Visitor<'a, E, S>>
         path: &Path<'a, E>,
     ) {
         if let Some(directives) = inline_fragment.directives() {
-            self.visit_variable_directives(
-                directives,
-                DirectiveLocation::InlineFragment,
-                &path,
-            );
+            self.visit_variable_directives(directives, DirectiveLocation::InlineFragment, path);
         }
 
         let fragment_type = if let Some(type_condition) = inline_fragment.type_condition() {
@@ -269,11 +261,7 @@ impl<'a, E: ExecutableDocument, S: SchemaDefinition, V: Visitor<'a, E, S>>
         path: &Path<'a, E>,
     ) {
         if let Some(directives) = fragment_spread.directives() {
-            self.visit_variable_directives(
-                directives,
-                DirectiveLocation::FragmentSpread,
-                &path,
-            );
+            self.visit_variable_directives(directives, DirectiveLocation::FragmentSpread, path);
         }
 
         self.visitor
@@ -286,10 +274,7 @@ impl<'a, E: ExecutableDocument, S: SchemaDefinition, V: Visitor<'a, E, S>>
             .visit_variable_definitions(variable_definitions);
         variable_definitions.iter().for_each(|variable_definition| {
             if let Some(directives) = variable_definition.directives() {
-                self.visit_const_directives(
-                    directives,
-                    DirectiveLocation::VariableDefinition,
-                );
+                self.visit_const_directives(directives, DirectiveLocation::VariableDefinition);
             }
             self.visitor.visit_variable_definition(variable_definition);
         });

--- a/bluejay-validator/src/executable/operation/orchestrator.rs
+++ b/bluejay-validator/src/executable/operation/orchestrator.rs
@@ -138,10 +138,10 @@ impl<
         owner_type: TypeDefinitionReference<'a, S::TypeDefinition>,
         included: bool,
     ) {
-        let mut included = included;
-        if let Some(directives) = field.directives() {
-            included = included && self.evaluate_selection_inclusion(directives);
-        }
+        let included = included
+            && field.directives().map_or(true, |directives| {
+                self.evaluate_selection_inclusion(directives)
+            });
 
         self.visitor
             .visit_field(field, field_definition, owner_type, included);
@@ -165,10 +165,10 @@ impl<
         scoped_type: TypeDefinitionReference<'a, S::TypeDefinition>,
         included: bool,
     ) {
-        let mut included = included;
-        if let Some(directives) = inline_fragment.directives() {
-            included = included && self.evaluate_selection_inclusion(directives);
-        }
+        let included = included
+            && inline_fragment.directives().map_or(true, |directives| {
+                self.evaluate_selection_inclusion(directives)
+            });
 
         let fragment_type = if let Some(type_condition) = inline_fragment.type_condition() {
             self.schema_definition.get_type_definition(type_condition)
@@ -182,10 +182,10 @@ impl<
     }
 
     fn visit_fragment_spread(&mut self, fragment_spread: &'a E::FragmentSpread, included: bool) {
-        let mut included = included;
-        if let Some(directives) = fragment_spread.directives() {
-            included = included && self.evaluate_selection_inclusion(directives);
-        }
+        let included = included
+            && fragment_spread.directives().map_or(true, |directives| {
+                self.evaluate_selection_inclusion(directives)
+            });
         if self
             .currently_spread_fragments
             .insert(fragment_spread.name())

--- a/bluejay-validator/src/executable/operation/orchestrator.rs
+++ b/bluejay-validator/src/executable/operation/orchestrator.rs
@@ -138,7 +138,10 @@ impl<
         owner_type: TypeDefinitionReference<'a, S::TypeDefinition>,
         included: bool,
     ) {
-        let included = included && self.evaluate_selection_inclusion(field.directives());
+        let mut included = included;
+        if let Some(directives) = field.directives() {
+            included = included && self.evaluate_selection_inclusion(directives);
+        }
 
         self.visitor
             .visit_field(field, field_definition, owner_type, included);
@@ -162,7 +165,10 @@ impl<
         scoped_type: TypeDefinitionReference<'a, S::TypeDefinition>,
         included: bool,
     ) {
-        let included = included && self.evaluate_selection_inclusion(inline_fragment.directives());
+        let mut included = included;
+        if let Some(directives) = inline_fragment.directives() {
+            included = included && self.evaluate_selection_inclusion(directives);
+        }
 
         let fragment_type = if let Some(type_condition) = inline_fragment.type_condition() {
             self.schema_definition.get_type_definition(type_condition)
@@ -176,7 +182,10 @@ impl<
     }
 
     fn visit_fragment_spread(&mut self, fragment_spread: &'a E::FragmentSpread, included: bool) {
-        let included = included && self.evaluate_selection_inclusion(fragment_spread.directives());
+        let mut included = included;
+        if let Some(directives) = fragment_spread.directives() {
+            included = included && self.evaluate_selection_inclusion(directives);
+        }
         if self
             .currently_spread_fragments
             .insert(fragment_spread.name())


### PR DESCRIPTION
Resolves #12 

This transforms the `executable` document directives into an `Option<Directives>`, currently this already reduces the overall memory footprint of the AST by returning `None` when there are no directives present on the ExecutableDefinition. The allocations however do happen when we are parsing, a future optimization here would be to peek and see whether we actually have directives, if there are none we can skip the allocations completely. I saw that we have the same redundant `vec` allocation in the `SchemaDefinition`, this does mean that we have a slight discrepancy when there's `None` in the `definition.directives` between `executable` and `schema` because we add an additional bail case for an empty `vec`.

Do note that this is in theory a breaking change, this would make for `bluejay-core` 0.2.0