### PR TITLE
chore(parser): Optimize string parsing

### DIFF
--- a/bluejay-parser/src/lexer/logos_lexer.rs
+++ b/bluejay-parser/src/lexer/logos_lexer.rs
@@ -56,7 +56,7 @@ pub(crate) enum Token<'a> {
     Pipe,
 
     // Name
-    #[regex(r"[a-zA-Z_]\w*")]
+    #[regex(r"[_a-zA-Z][_0-9a-zA-Z]*")]
     Name(&'a str),
 
     // IntValue


### PR DESCRIPTION
Small tweak that makes us go from

```
time:   [12.726 µs 12.756 µs 12.793 µs]
```

to

```
time:   [11.633 µs 11.662 µs 11.696 µs]
```

Which is a 8-9% difference.

I did notice two things while tackling this

- We could optimize directives/variables by removing the dollar/at tokens and just making a Variable/Directive one instead - this might however sacrifice some error messages...
- Int and Float values are currently stored as `i32`/`f64` which isn't completely spec-compliant, https://github.com/graphql/graphql-js/issues/4014#issuecomment-1916533068