### PR TITLE
Optimize boolean value parsing

### DIFF
--- a/bluejay-parser/src/ast/tokens.rs
+++ b/bluejay-parser/src/ast/tokens.rs
@@ -1,6 +1,8 @@
 use crate::ast::parse_error::ParseError;
 use crate::lexer::{LexError, Lexer};
-use crate::lexical_token::{FloatValue, IntValue, LexicalToken, Name, PunctuatorType, StringValue};
+use crate::lexical_token::{
+    BooleanValue, FloatValue, IntValue, LexicalToken, Name, PunctuatorType, StringValue,
+};
 use crate::{HasSpan, Span};
 use std::collections::VecDeque;
 
@@ -13,6 +15,7 @@ pub trait Tokens<'a>: Iterator<Item = LexicalToken<'a>> {
     fn next_if_punctuator(&mut self, punctuator_type: PunctuatorType) -> Option<Span>;
     fn next_if_int_value(&mut self) -> Option<IntValue>;
     fn next_if_float_value(&mut self) -> Option<FloatValue>;
+    fn next_if_boolean_value(&mut self) -> Option<BooleanValue>;
     fn next_if_string_value(&mut self) -> Option<StringValue<'a>>;
     fn next_if_name(&mut self) -> Option<Name<'a>>;
     fn next_if_name_matches(&mut self, name: &str) -> Option<Span>;
@@ -132,6 +135,11 @@ impl<'a, T: Lexer<'a>> LexerTokens<'a, T> {
             .then(|| self.next().unwrap().into_float_value().unwrap())
     }
 
+    pub fn next_if_boolean_value(&mut self) -> Option<BooleanValue> {
+        matches!(self.peek_next(), Some(LexicalToken::BooleanValue(_)))
+            .then(|| self.next().unwrap().into_boolean_value().unwrap())
+    }
+
     pub fn next_if_string_value(&mut self) -> Option<StringValue<'a>> {
         matches!(self.peek_next(), Some(LexicalToken::StringValue(_)))
             .then(|| self.next().unwrap().into_string_value().unwrap())
@@ -193,6 +201,10 @@ impl<'a, T: Lexer<'a>> Tokens<'a> for LexerTokens<'a, T> {
 
     fn unexpected_eof(&self) -> ParseError {
         self.unexpected_eof()
+    }
+
+    fn next_if_boolean_value(&mut self) -> Option<BooleanValue> {
+        self.next_if_boolean_value()
     }
 
     fn unexpected_token(&mut self) -> ParseError {

--- a/bluejay-parser/src/lexer/logos_lexer.rs
+++ b/bluejay-parser/src/lexer/logos_lexer.rs
@@ -1,6 +1,6 @@
 use crate::lexer::{LexError, Lexer};
 use crate::lexical_token::{
-    FloatValue, IntValue, LexicalToken, Name, Punctuator, PunctuatorType, StringValue,
+    BooleanValue, FloatValue, IntValue, LexicalToken, Name, Punctuator, PunctuatorType, StringValue,
 };
 use crate::Span;
 use logos::Logos;
@@ -59,6 +59,10 @@ pub(crate) enum Token<'a> {
     #[regex(r"[_a-zA-Z][_0-9a-zA-Z]*")]
     Name(&'a str),
 
+    // BooleanValue
+    #[regex(r"(true|false)", parse_boolean)]
+    BooleanValue(bool),
+
     // IntValue
     #[regex(r"(?&intpart)", parse_integer)]
     IntValue(i32),
@@ -98,6 +102,13 @@ fn validate_number_no_trailing_name_start<'a>(
     } else {
         Err(LexError::UnrecognizedToken)
     }
+}
+
+fn parse_boolean<'a>(lexer: &mut logos::Lexer<'a, Token<'a>>) -> Result<bool, LexError> {
+    lexer
+        .slice()
+        .parse()
+        .map_err(|_| LexError::UnrecognizedToken)
 }
 
 fn parse_integer<'a>(lexer: &mut logos::Lexer<'a, Token<'a>>) -> Result<i32, LexError> {
@@ -156,6 +167,9 @@ impl<'a> Iterator for LogosLexer<'a> {
                         Token::IntValue(val) => LexicalToken::IntValue(IntValue::new(val, span)),
                         Token::FloatValue(val) => {
                             LexicalToken::FloatValue(FloatValue::new(val, span))
+                        }
+                        Token::BooleanValue(val) => {
+                            LexicalToken::BooleanValue(BooleanValue::new(val, span))
                         }
                         Token::StringValue(val) => {
                             LexicalToken::StringValue(StringValue::new(val, span))

--- a/bluejay-parser/src/lexical_token.rs
+++ b/bluejay-parser/src/lexical_token.rs
@@ -1,11 +1,13 @@
 use crate::{HasSpan, Span};
 use enum_as_inner::EnumAsInner;
 
+mod bool_value;
 mod float_value;
 mod int_value;
 mod name;
 mod punctuator;
 mod string_value;
+pub use bool_value::BooleanValue;
 pub use float_value::FloatValue;
 pub use int_value::IntValue;
 pub use name::Name;
@@ -19,6 +21,7 @@ pub enum LexicalToken<'a> {
     IntValue(IntValue),
     FloatValue(FloatValue),
     StringValue(StringValue<'a>),
+    BooleanValue(BooleanValue),
 }
 
 impl<'a> HasSpan for LexicalToken<'a> {
@@ -29,6 +32,7 @@ impl<'a> HasSpan for LexicalToken<'a> {
             Self::StringValue(s) => s.span(),
             Self::Name(n) => n.span(),
             Self::Punctuator(p) => p.span(),
+            Self::BooleanValue(p) => p.span(),
         }
     }
 }
@@ -41,6 +45,7 @@ impl<'a> From<LexicalToken<'a>> for Span {
             LexicalToken::StringValue(s) => s.into(),
             LexicalToken::Name(n) => n.into(),
             LexicalToken::Punctuator(p) => p.into(),
+            LexicalToken::BooleanValue(p) => p.into(),
         }
     }
 }

--- a/bluejay-parser/src/lexical_token/bool_value.rs
+++ b/bluejay-parser/src/lexical_token/bool_value.rs
@@ -1,0 +1,42 @@
+use crate::lexical_token::HasSpan;
+use crate::Span;
+
+#[derive(PartialEq, Debug)]
+pub struct BooleanValue {
+    value: bool,
+    span: Span,
+}
+
+impl BooleanValue {
+    pub(crate) fn value(&self) -> bool {
+        self.value
+    }
+
+    pub(crate) fn new(value: bool, span: Span) -> Self {
+        Self { value, span }
+    }
+}
+
+impl HasSpan for BooleanValue {
+    fn span(&self) -> &Span {
+        &self.span
+    }
+}
+
+impl From<BooleanValue> for Span {
+    fn from(value: BooleanValue) -> Self {
+        value.span
+    }
+}
+
+impl From<BooleanValue> for bool {
+    fn from(val: BooleanValue) -> Self {
+        val.value
+    }
+}
+
+impl AsRef<bool> for BooleanValue {
+    fn as_ref(&self) -> &bool {
+        &self.value
+    }
+}


### PR DESCRIPTION
Small tweak that makes us go from

```
time:   [11.633 µs 11.662 µs 11.696 µs]
```

to

```
time:   [11.223 µs 11.256 µs 11.293 µs]

```