### PR TITLE
chore(validation): improve field merging perf

### DIFF
--- a/bluejay-validator/src/executable/document/rules/field_selection_merging.rs
+++ b/bluejay-validator/src/executable/document/rules/field_selection_merging.rs
@@ -283,7 +283,7 @@ impl<'a, E: ExecutableDocument + 'a, S: SchemaDefinition + 'a> FieldSelectionMer
                         .push(FieldContext {
                             field,
                             field_definition,
-                            parent_type: parent_type.to_owned(),
+                            parent_type,
                             parent_fragments: parent_fragments.to_owned(),
                         });
                 }
@@ -297,17 +297,18 @@ impl<'a, E: ExecutableDocument + 'a, S: SchemaDefinition + 'a> FieldSelectionMer
                         if let Some(scoped_type) =
                             self.schema_definition.get_type_definition(type_condition)
                         {
-                            let mut parent_fragments = parent_fragments.clone();
-                            parent_fragments.insert(fragment_name);
                             if self.selection_set_valid(
                                 fragment_definition.selection_set(),
                                 parent_type,
                             ) {
+                                let mut new_parent_fragments = HashSet::new();
+                                new_parent_fragments.clone_from(parent_fragments);
+                                new_parent_fragments.insert(fragment_name);
                                 self.visit_selections_for_fields(
                                     fragment_definition.selection_set().iter(),
                                     fields,
                                     scoped_type,
-                                    &parent_fragments,
+                                    &new_parent_fragments,
                                 );
                             }
                         }


### PR DESCRIPTION
This reduces some clones in the field-merging validation, other things that could make for _huge_ improvements would be replacing the `HashMap`/`HashSet` with i.e. the fnv one to use a cheaper hash algorithm

```
field_selection_merging/4
                        time:   [20.246 µs 20.323 µs 20.402 µs]
                        thrpt:  [196.06 Kelem/s 196.83 Kelem/s 197.57 Kelem/s]
                 change:
                        time:   [-15.060% -11.997% -9.3000%] (p = 0.00 < 0.05)
                        thrpt:  [+10.254% +13.632% +17.731%]
                        Performance has improved.

Benchmarking field_selection_merging/8: Collecting 100 samples in estimated 5.1414 s (1
field_selection_merging/8
                        time:   [40.462 µs 40.562 µs 40.679 µs]
                        thrpt:  [196.66 Kelem/s 197.23 Kelem/s 197.72 Kelem/s]
                 change:
                        time:   [-5.0285% -4.2238% -3.5624%] (p = 0.00 < 0.05)
                        thrpt:  [+3.6940% +4.4101% +5.2948%]
                        Performance has improved.

Benchmarking field_selection_merging/16: Collecting 100 samples in estimated 5.2021 s (
field_selection_merging/16
                        time:   [78.881 µs 79.088 µs 79.331 µs]
                        thrpt:  [201.69 Kelem/s 202.31 Kelem/s 202.84 Kelem/s]
                 change:
                        time:   [-6.1810% -5.6472% -5.1397%] (p = 0.00 < 0.05)
                        thrpt:  [+5.4181% +5.9852% +6.5882%]
                        Performance has improved.

Benchmarking field_selection_merging/32: Collecting 100 samples in estimated 5.5101 s (
field_selection_merging/32
                        time:   [155.16 µs 155.56 µs 156.02 µs]
                        thrpt:  [205.10 Kelem/s 205.71 Kelem/s 206.24 Kelem/s]
                 change:
                        time:   [-2.7250% -2.3101% -1.8462%] (p = 0.00 < 0.05)
                        thrpt:  [+1.8809% +2.3647% +2.8013%]
                        Performance has improved.

Benchmarking field_selection_merging/64: Collecting 100 samples in estimated 6.2080 s (
field_selection_merging/64
                        time:   [308.94 µs 310.07 µs 311.24 µs]
                        thrpt:  [205.63 Kelem/s 206.40 Kelem/s 207.16 Kelem/s]
                 change:
                        time:   [+0.3201% +0.7595% +1.1876%] (p = 0.00 < 0.05)
                        thrpt:  [-1.1737% -0.7538% -0.3190%]
                        Change within noise threshold.

Benchmarking field_selection_merging/128: Collecting 100 samples in estimated 6.1466 s 
field_selection_merging/128
                        time:   [606.50 µs 607.85 µs 609.47 µs]
                        thrpt:  [210.02 Kelem/s 210.58 Kelem/s 211.05 Kelem/s]
                 change:
                        time:   [-4.5470% -3.9520% -3.3430%] (p = 0.00 < 0.05)
                        thrpt:  [+3.4587% +4.1146% +4.7636%]
                        Performance has improved.
```