### PR TITLE
chore(parser): Switch a few unwraps to lazy evaulation

### DIFF
--- a/bluejay-core/src/executable/field.rs
+++ b/bluejay-core/src/executable/field.rs
@@ -13,6 +13,6 @@ pub trait Field {
     fn selection_set(&self) -> Option<&Self::SelectionSet>;
 
     fn response_name(&self) -> &str {
-        self.alias().unwrap_or(self.name())
+        self.alias().unwrap_or_else(|| self.name())
     }
 }

--- a/bluejay-parser/src/ast/executable/variable_type.rs
+++ b/bluejay-parser/src/ast/executable/variable_type.rs
@@ -60,7 +60,7 @@ impl<'a> FromTokens<'a> for VariableType<'a> {
             let is_required = bang_span.is_some();
             let span = bang_span
                 .map(|bang_span| name.span().merge(&bang_span))
-                .unwrap_or(name.span().clone());
+                .unwrap_or_else(|| name.span().clone());
             Ok(Self::Named {
                 name,
                 is_required,

--- a/bluejay-parser/src/lexer/logos_lexer.rs
+++ b/bluejay-parser/src/lexer/logos_lexer.rs
@@ -89,7 +89,7 @@ fn validate_number_no_trailing_name_start<'a>(
         .remainder()
         .chars()
         .position(|c| !(c.is_ascii_alphanumeric() || matches!(c, '_' | '.')))
-        .unwrap_or(lexer.remainder().len());
+        .unwrap_or_else(|| lexer.remainder().len());
 
     lexer.bump(invalid_trail_bytes);
 


### PR DESCRIPTION
This adds a few lazy evaluations to reduce allocations/invocations

```
parse kitchen sink executable document
                        time:   [11.514 µs 11.547 µs 11.581 µs]
                        change: [-1.8001% -1.4063% -0.9678%] (p = 0.00 < 0.05)
```