### PR TITLE
chore(parser): Improve performance by inlining functions

### DIFF
--- a/bluejay-parser/src/ast/argument.rs
+++ b/bluejay-parser/src/ast/argument.rs
@@ -23,6 +23,7 @@ pub type ConstArgument<'a> = Argument<'a, true>;
 pub type VariableArgument<'a> = Argument<'a, false>;
 
 impl<'a, const CONST: bool> FromTokens<'a> for Argument<'a, CONST> {
+    #[inline]
     fn from_tokens(tokens: &mut impl Tokens<'a>) -> Result<Self, ParseError> {
         let name = tokens.expect_name()?;
         tokens.expect_punctuator(PunctuatorType::Colon)?;

--- a/bluejay-parser/src/ast/arguments.rs
+++ b/bluejay-parser/src/ast/arguments.rs
@@ -12,6 +12,7 @@ pub struct Arguments<'a, const CONST: bool> {
 pub type VariableArguments<'a> = Arguments<'a, false>;
 
 impl<'a, const CONST: bool> FromTokens<'a> for Arguments<'a, CONST> {
+    #[inline]
     fn from_tokens(tokens: &mut impl Tokens<'a>) -> Result<Self, ParseError> {
         let open_span = tokens.expect_punctuator(PunctuatorType::OpenRoundBracket)?;
         let mut arguments: Vec<Argument<CONST>> = Vec::new();
@@ -27,6 +28,7 @@ impl<'a, const CONST: bool> FromTokens<'a> for Arguments<'a, CONST> {
 }
 
 impl<'a, const CONST: bool> IsMatch<'a> for Arguments<'a, CONST> {
+    #[inline]
     fn is_match(tokens: &mut impl Tokens<'a>) -> bool {
         tokens.peek_punctuator_matches(0, PunctuatorType::OpenRoundBracket)
     }

--- a/bluejay-parser/src/ast/directive.rs
+++ b/bluejay-parser/src/ast/directive.rs
@@ -13,12 +13,14 @@ pub type ConstDirective<'a> = Directive<'a, true>;
 pub type VariableDirective<'a> = Directive<'a, false>;
 
 impl<'a, const CONST: bool> IsMatch<'a> for Directive<'a, CONST> {
+    #[inline]
     fn is_match(tokens: &mut impl Tokens<'a>) -> bool {
         tokens.peek_punctuator_matches(0, PunctuatorType::At)
     }
 }
 
 impl<'a, const CONST: bool> FromTokens<'a> for Directive<'a, CONST> {
+    #[inline]
     fn from_tokens(tokens: &mut impl Tokens<'a>) -> Result<Self, ParseError> {
         let at_span = tokens.expect_punctuator(PunctuatorType::At)?;
         let name = tokens.expect_name()?;

--- a/bluejay-parser/src/ast/directives.rs
+++ b/bluejay-parser/src/ast/directives.rs
@@ -14,6 +14,7 @@ pub type ConstDirectives<'a> = Directives<'a, true>;
 pub type VariableDirectives<'a> = Directives<'a, false>;
 
 impl<'a, const CONST: bool> FromTokens<'a> for Directives<'a, CONST> {
+    #[inline]
     fn from_tokens(tokens: &mut impl Tokens<'a>) -> Result<Self, ParseError> {
         let mut directives: Vec<Directive<'a, CONST>> = Vec::new();
         while let Some(directive) = Directive::try_from_tokens(tokens) {
@@ -29,6 +30,7 @@ impl<'a, const CONST: bool> FromTokens<'a> for Directives<'a, CONST> {
 }
 
 impl<'a, const CONST: bool> IsMatch<'a> for Directives<'a, CONST> {
+    #[inline]
     fn is_match(tokens: &mut impl Tokens<'a>) -> bool {
         Directive::<'a, CONST>::is_match(tokens)
     }

--- a/bluejay-parser/src/ast/executable/executable_definition.rs
+++ b/bluejay-parser/src/ast/executable/executable_definition.rs
@@ -8,6 +8,7 @@ pub enum ExecutableDefinition<'a> {
 }
 
 impl<'a> FromTokens<'a> for ExecutableDefinition<'a> {
+    #[inline]
     fn from_tokens(tokens: &mut impl Tokens<'a>) -> Result<Self, ParseError> {
         if OperationDefinition::is_match(tokens) {
             OperationDefinition::from_tokens(tokens).map(Self::Operation)
@@ -20,6 +21,7 @@ impl<'a> FromTokens<'a> for ExecutableDefinition<'a> {
 }
 
 impl<'a> IsMatch<'a> for ExecutableDefinition<'a> {
+    #[inline]
     fn is_match(tokens: &mut impl Tokens<'a>) -> bool {
         OperationDefinition::is_match(tokens) || FragmentDefinition::is_match(tokens)
     }

--- a/bluejay-parser/src/ast/executable/executable_document.rs
+++ b/bluejay-parser/src/ast/executable/executable_document.rs
@@ -33,12 +33,14 @@ impl<'a> ExecutableDocument<'a> {
         &self.fragment_definitions
     }
 
+    #[inline]
     fn is_empty(&self) -> bool {
         self.operation_definitions.is_empty() && self.fragment_definitions.is_empty()
     }
 }
 
 impl<'a> Parse<'a> for ExecutableDocument<'a> {
+    #[inline]
     fn parse_from_tokens(mut tokens: impl Tokens<'a>) -> Result<Self, Vec<Error>> {
         let mut instance: Self = Self::new(Vec::new(), Vec::new());
         let mut errors = Vec::new();

--- a/bluejay-parser/src/ast/executable/field.rs
+++ b/bluejay-parser/src/ast/executable/field.rs
@@ -18,6 +18,7 @@ pub struct Field<'a> {
 }
 
 impl<'a> FromTokens<'a> for Field<'a> {
+    #[inline]
     fn from_tokens(tokens: &mut impl Tokens<'a>) -> Result<Self, ParseError> {
         let has_alias = tokens.peek_punctuator_matches(1, PunctuatorType::Colon);
         let (alias, name) = if has_alias {
@@ -55,6 +56,7 @@ impl<'a> FromTokens<'a> for Field<'a> {
 }
 
 impl<'a> IsMatch<'a> for Field<'a> {
+    #[inline]
     fn is_match(tokens: &mut impl Tokens<'a>) -> bool {
         tokens.peek_name(0).is_some()
     }

--- a/bluejay-parser/src/ast/executable/fragment_definition.rs
+++ b/bluejay-parser/src/ast/executable/fragment_definition.rs
@@ -14,12 +14,14 @@ pub struct FragmentDefinition<'a> {
 }
 
 impl<'a> IsMatch<'a> for FragmentDefinition<'a> {
+    #[inline]
     fn is_match(tokens: &mut impl Tokens<'a>) -> bool {
         tokens.peek_name_matches(0, "fragment")
     }
 }
 
 impl<'a> FromTokens<'a> for FragmentDefinition<'a> {
+    #[inline]
     fn from_tokens(tokens: &mut impl Tokens<'a>) -> Result<Self, ParseError> {
         let fragment_identifier_span = tokens.expect_name_value("fragment")?;
         let name = tokens.expect_name()?;

--- a/bluejay-parser/src/ast/executable/fragment_spread.rs
+++ b/bluejay-parser/src/ast/executable/fragment_spread.rs
@@ -12,6 +12,7 @@ pub struct FragmentSpread<'a> {
 }
 
 impl<'a> FromTokens<'a> for FragmentSpread<'a> {
+    #[inline]
     fn from_tokens(tokens: &mut impl Tokens<'a>) -> Result<Self, ParseError> {
         let ellipse_span = tokens.expect_punctuator(PunctuatorType::Ellipse)?;
         let name = tokens.expect_name()?;
@@ -27,6 +28,7 @@ impl<'a> FromTokens<'a> for FragmentSpread<'a> {
 }
 
 impl<'a> IsMatch<'a> for FragmentSpread<'a> {
+    #[inline]
     fn is_match(tokens: &mut impl Tokens<'a>) -> bool {
         tokens.peek_punctuator_matches(0, PunctuatorType::Ellipse)
             && tokens

--- a/bluejay-parser/src/ast/executable/inline_fragment.rs
+++ b/bluejay-parser/src/ast/executable/inline_fragment.rs
@@ -12,6 +12,7 @@ pub struct InlineFragment<'a> {
 }
 
 impl<'a> FromTokens<'a> for InlineFragment<'a> {
+    #[inline]
     fn from_tokens(tokens: &mut impl Tokens<'a>) -> Result<Self, ParseError> {
         let ellipse_span = tokens.expect_punctuator(PunctuatorType::Ellipse)?;
         let type_condition = TypeCondition::try_from_tokens(tokens).transpose()?;
@@ -28,6 +29,7 @@ impl<'a> FromTokens<'a> for InlineFragment<'a> {
 }
 
 impl<'a> IsMatch<'a> for InlineFragment<'a> {
+    #[inline]
     fn is_match(tokens: &mut impl Tokens<'a>) -> bool {
         tokens.peek_punctuator_matches(0, PunctuatorType::Ellipse)
             && tokens

--- a/bluejay-parser/src/ast/executable/operation_definition.rs
+++ b/bluejay-parser/src/ast/executable/operation_definition.rs
@@ -45,6 +45,7 @@ impl<'a> CoreOperationDefinition for OperationDefinition<'a> {
 }
 
 impl<'a> FromTokens<'a> for OperationDefinition<'a> {
+    #[inline]
     fn from_tokens(tokens: &mut impl Tokens<'a>) -> Result<Self, ParseError> {
         if let Some(operation_type) = OperationType::try_from_tokens(tokens).transpose()? {
             let name = tokens.next_if_name();
@@ -71,6 +72,7 @@ impl<'a> FromTokens<'a> for OperationDefinition<'a> {
 }
 
 impl<'a> IsMatch<'a> for OperationDefinition<'a> {
+    #[inline]
     fn is_match(tokens: &mut impl Tokens<'a>) -> bool {
         OperationType::is_match(tokens) || SelectionSet::is_match(tokens)
     }

--- a/bluejay-parser/src/ast/executable/selection.rs
+++ b/bluejay-parser/src/ast/executable/selection.rs
@@ -25,6 +25,7 @@ impl<'a> CoreSelection for Selection<'a> {
 }
 
 impl<'a> FromTokens<'a> for Selection<'a> {
+    #[inline]
     fn from_tokens(tokens: &mut impl Tokens<'a>) -> Result<Self, ParseError> {
         if Field::is_match(tokens) {
             Field::from_tokens(tokens).map(Self::Field)
@@ -39,6 +40,7 @@ impl<'a> FromTokens<'a> for Selection<'a> {
 }
 
 impl<'a> IsMatch<'a> for Selection<'a> {
+    #[inline]
     fn is_match(tokens: &mut impl Tokens<'a>) -> bool {
         Field::is_match(tokens) || tokens.peek_punctuator_matches(0, PunctuatorType::Ellipse)
     }

--- a/bluejay-parser/src/ast/executable/selection_set.rs
+++ b/bluejay-parser/src/ast/executable/selection_set.rs
@@ -11,6 +11,7 @@ pub struct SelectionSet<'a> {
 }
 
 impl<'a> FromTokens<'a> for SelectionSet<'a> {
+    #[inline]
     fn from_tokens(tokens: &mut impl Tokens<'a>) -> Result<Self, ParseError> {
         let open_span = tokens.expect_punctuator(PunctuatorType::OpenBrace)?;
         let mut selections: Vec<Selection> = Vec::new();
@@ -26,6 +27,7 @@ impl<'a> FromTokens<'a> for SelectionSet<'a> {
 }
 
 impl<'a> IsMatch<'a> for SelectionSet<'a> {
+    #[inline]
     fn is_match(tokens: &mut impl Tokens<'a>) -> bool {
         tokens.peek_punctuator_matches(0, PunctuatorType::OpenBrace)
     }

--- a/bluejay-parser/src/ast/executable/type_condition.rs
+++ b/bluejay-parser/src/ast/executable/type_condition.rs
@@ -7,6 +7,7 @@ pub struct TypeCondition<'a> {
 }
 
 impl<'a> FromTokens<'a> for TypeCondition<'a> {
+    #[inline]
     fn from_tokens(tokens: &mut impl Tokens<'a>) -> Result<Self, ParseError> {
         tokens.expect_name_value(Self::ON)?;
         let named_type = tokens.expect_name()?;
@@ -15,6 +16,7 @@ impl<'a> FromTokens<'a> for TypeCondition<'a> {
 }
 
 impl<'a> IsMatch<'a> for TypeCondition<'a> {
+    #[inline]
     fn is_match(tokens: &mut impl Tokens<'a>) -> bool {
         tokens.peek_name_matches(0, Self::ON)
     }

--- a/bluejay-parser/src/ast/executable/variable_definition.rs
+++ b/bluejay-parser/src/ast/executable/variable_definition.rs
@@ -13,6 +13,7 @@ pub struct VariableDefinition<'a> {
 }
 
 impl<'a> FromTokens<'a> for VariableDefinition<'a> {
+    #[inline]
     fn from_tokens(tokens: &mut impl Tokens<'a>) -> Result<Self, ParseError> {
         let variable = tokens.expect_variable()?;
         tokens.expect_punctuator(PunctuatorType::Colon)?;

--- a/bluejay-parser/src/ast/executable/variable_definitions.rs
+++ b/bluejay-parser/src/ast/executable/variable_definitions.rs
@@ -11,6 +11,7 @@ pub struct VariableDefinitions<'a> {
 }
 
 impl<'a> FromTokens<'a> for VariableDefinitions<'a> {
+    #[inline]
     fn from_tokens(tokens: &mut impl Tokens<'a>) -> Result<Self, ParseError> {
         let open_span = tokens.expect_punctuator(PunctuatorType::OpenRoundBracket)?;
         let mut variable_definitions: Vec<VariableDefinition> = Vec::new();
@@ -29,6 +30,7 @@ impl<'a> FromTokens<'a> for VariableDefinitions<'a> {
 }
 
 impl<'a> IsMatch<'a> for VariableDefinitions<'a> {
+    #[inline]
     fn is_match(tokens: &mut impl Tokens<'a>) -> bool {
         tokens.peek_punctuator_matches(0, PunctuatorType::OpenRoundBracket)
     }

--- a/bluejay-parser/src/ast/executable/variable_type.rs
+++ b/bluejay-parser/src/ast/executable/variable_type.rs
@@ -42,6 +42,7 @@ impl<'a> CoreVariableType for VariableType<'a> {
 }
 
 impl<'a> FromTokens<'a> for VariableType<'a> {
+    #[inline]
     fn from_tokens(tokens: &mut impl Tokens<'a>) -> Result<Self, ParseError> {
         if let Some(open_span) = tokens.next_if_punctuator(PunctuatorType::OpenSquareBracket) {
             let inner = Box::new(VariableType::from_tokens(tokens)?);

--- a/bluejay-parser/src/ast/operation_type.rs
+++ b/bluejay-parser/src/ast/operation_type.rs
@@ -20,6 +20,7 @@ impl From<&OperationType> for bluejay_core::OperationType {
 }
 
 impl<'a> FromTokens<'a> for OperationType {
+    #[inline]
     fn from_tokens(tokens: &mut impl Tokens<'a>) -> Result<Self, ParseError> {
         tokens.expect_name().and_then(|name| {
             match bluejay_core::OperationType::try_from(name.as_str()) {
@@ -37,6 +38,7 @@ impl<'a> FromTokens<'a> for OperationType {
 }
 
 impl<'a> IsMatch<'a> for OperationType {
+    #[inline]
     fn is_match(tokens: &mut impl Tokens<'a>) -> bool {
         bluejay_core::OperationType::POSSIBLE_VALUES
             .iter()

--- a/bluejay-parser/src/ast/parse.rs
+++ b/bluejay-parser/src/ast/parse.rs
@@ -8,10 +8,12 @@ pub struct ParseOptions {
 }
 
 pub trait Parse<'a>: Sized {
+    #[inline]
     fn parse(s: &'a str) -> Result<Self, Vec<Error>> {
         Self::parse_with_options(s, Default::default())
     }
 
+    #[inline]
     fn parse_with_options(s: &'a str, options: ParseOptions) -> Result<Self, Vec<Error>> {
         let lexer =
             LogosLexer::new(s).with_graphql_ruby_compatibility(options.graphql_ruby_compatibility);
@@ -24,6 +26,7 @@ pub trait Parse<'a>: Sized {
 }
 
 impl<'a, T: FromTokens<'a>> Parse<'a> for T {
+    #[inline]
     fn parse_from_tokens(mut tokens: impl Tokens<'a>) -> Result<Self, Vec<Error>> {
         let result = T::from_tokens(&mut tokens);
 

--- a/bluejay-parser/src/ast/tokens.rs
+++ b/bluejay-parser/src/ast/tokens.rs
@@ -34,6 +34,7 @@ pub struct LexerTokens<'a, T: Lexer<'a>> {
 }
 
 impl<'a, T: Lexer<'a>> LexerTokens<'a, T> {
+    #[inline]
     pub fn new(lexer: T) -> Self {
         Self {
             lexer,
@@ -42,11 +43,13 @@ impl<'a, T: Lexer<'a>> LexerTokens<'a, T> {
         }
     }
 
+    #[inline]
     pub fn peek<'b, 'c: 'b>(&'c mut self, idx: usize) -> Option<&'b LexicalToken> {
         self.compute_up_to(idx);
         self.buffer.get(idx)
     }
 
+    #[inline]
     pub fn peek_next(&mut self) -> Option<&LexicalToken> {
         self.peek(0)
     }
@@ -63,6 +66,7 @@ impl<'a, T: Lexer<'a>> LexerTokens<'a, T> {
         }
     }
 
+    #[inline]
     pub fn expect_name(&mut self) -> Result<Name<'a>, ParseError> {
         match self.next() {
             Some(LexicalToken::Name(n)) => Ok(n),
@@ -71,6 +75,7 @@ impl<'a, T: Lexer<'a>> LexerTokens<'a, T> {
         }
     }
 
+    #[inline]
     pub fn expect_variable(&mut self) -> Result<Variable<'a>, ParseError> {
         match self.next() {
             Some(LexicalToken::VariableName(n)) => Ok(n),
@@ -82,6 +87,7 @@ impl<'a, T: Lexer<'a>> LexerTokens<'a, T> {
         }
     }
 
+    #[inline]
     pub fn expect_name_value(&mut self, value: &str) -> Result<Span, ParseError> {
         match self.next() {
             Some(LexicalToken::Name(n)) if n.as_str() == value => Ok(n.into()),
@@ -93,6 +99,7 @@ impl<'a, T: Lexer<'a>> LexerTokens<'a, T> {
         }
     }
 
+    #[inline]
     pub fn expect_punctuator(
         &mut self,
         punctuator_type: PunctuatorType,
@@ -107,18 +114,21 @@ impl<'a, T: Lexer<'a>> LexerTokens<'a, T> {
         }
     }
 
+    #[inline]
     pub fn unexpected_eof(&self) -> ParseError {
         ParseError::UnexpectedEOF {
             span: self.lexer.empty_span(),
         }
     }
 
+    #[inline]
     pub fn unexpected_token(&mut self) -> ParseError {
         self.next()
             .map(|token| ParseError::UnexpectedToken { span: token.into() })
             .unwrap_or_else(|| self.unexpected_eof())
     }
 
+    #[inline]
     fn next_if<F>(&mut self, f: F) -> Option<Span>
     where
         F: Fn(&LexicalToken) -> bool,
@@ -133,50 +143,61 @@ impl<'a, T: Lexer<'a>> LexerTokens<'a, T> {
         }
     }
 
+    #[inline]
     pub fn next_if_punctuator(&mut self, punctuator_type: PunctuatorType) -> Option<Span> {
         self.next_if(|t| matches!(t, LexicalToken::Punctuator(p) if p.r#type() == punctuator_type))
     }
 
+    #[inline]
     pub fn next_if_int_value(&mut self) -> Option<IntValue> {
         matches!(self.peek_next(), Some(LexicalToken::IntValue(_)))
             .then(|| self.next().unwrap().into_int_value().unwrap())
     }
 
+    #[inline]
     pub fn next_if_float_value(&mut self) -> Option<FloatValue> {
         matches!(self.peek_next(), Some(LexicalToken::FloatValue(_)))
             .then(|| self.next().unwrap().into_float_value().unwrap())
     }
 
+    #[inline]
     pub fn next_if_string_value(&mut self) -> Option<StringValue<'a>> {
         matches!(self.peek_next(), Some(LexicalToken::StringValue(_)))
             .then(|| self.next().unwrap().into_string_value().unwrap())
     }
 
+    #[inline]
     pub fn next_if_name(&mut self) -> Option<Name<'a>> {
         matches!(self.peek_next(), Some(LexicalToken::Name(_)))
             .then(|| self.next().unwrap().into_name().unwrap())
     }
 
+    #[inline]
     pub fn next_if_name_matches(&mut self, name: &str) -> Option<Span> {
         self.next_if(|t| matches!(t, LexicalToken::Name(n) if n.as_str() == name))
     }
 
+    #[inline]
     pub fn peek_name(&mut self, n: usize) -> Option<&Name> {
         self.peek(n).and_then(LexicalToken::as_name)
     }
 
+    #[inline]
     pub fn peek_variable_name(&mut self, n: usize) -> bool {
         matches!(self.peek(n), Some(LexicalToken::VariableName(_)))
     }
 
+    #[inline]
     pub fn peek_name_matches(&mut self, n: usize, name: &str) -> bool {
         matches!(self.peek_name(n), Some(n) if n.as_str() == name)
     }
 
+    #[inline]
     pub fn peek_string_value(&mut self, n: usize) -> bool {
         matches!(self.peek(n), Some(LexicalToken::StringValue(_)))
     }
 
+    #[inline]
     pub fn peek_punctuator_matches(&mut self, n: usize, punctuator_type: PunctuatorType) -> bool {
         matches!(self.peek(n), Some(LexicalToken::Punctuator(p)) if p.r#type() == punctuator_type)
     }
@@ -185,6 +206,7 @@ impl<'a, T: Lexer<'a>> LexerTokens<'a, T> {
 impl<'a, T: Lexer<'a>> Iterator for LexerTokens<'a, T> {
     type Item = LexicalToken<'a>;
 
+    #[inline]
     fn next(&mut self) -> Option<Self::Item> {
         self.compute_up_to(0);
         self.buffer.pop_front()
@@ -198,74 +220,92 @@ impl<'a, T: Lexer<'a>> From<LexerTokens<'a, T>> for Vec<(LexError, Span)> {
 }
 
 impl<'a, T: Lexer<'a>> Tokens<'a> for LexerTokens<'a, T> {
+    #[inline]
     fn expect_variable(&mut self) -> Result<Variable<'a>, ParseError> {
         self.expect_variable()
     }
 
+    #[inline]
     fn expect_name(&mut self) -> Result<Name<'a>, ParseError> {
         self.expect_name()
     }
 
+    #[inline]
     fn expect_name_value(&mut self, value: &str) -> Result<Span, ParseError> {
         self.expect_name_value(value)
     }
 
+    #[inline]
     fn expect_punctuator(&mut self, punctuator_type: PunctuatorType) -> Result<Span, ParseError> {
         self.expect_punctuator(punctuator_type)
     }
 
+    #[inline]
     fn unexpected_eof(&self) -> ParseError {
         self.unexpected_eof()
     }
 
+    #[inline]
     fn unexpected_token(&mut self) -> ParseError {
         self.unexpected_token()
     }
 
+    #[inline]
     fn next_if_punctuator(&mut self, punctuator_type: PunctuatorType) -> Option<Span> {
         self.next_if_punctuator(punctuator_type)
     }
 
+    #[inline]
     fn next_if_int_value(&mut self) -> Option<IntValue> {
         self.next_if_int_value()
     }
 
+    #[inline]
     fn next_if_float_value(&mut self) -> Option<FloatValue> {
         self.next_if_float_value()
     }
 
+    #[inline]
     fn next_if_string_value(&mut self) -> Option<StringValue<'a>> {
         self.next_if_string_value()
     }
 
+    #[inline]
     fn next_if_name(&mut self) -> Option<Name<'a>> {
         self.next_if_name()
     }
 
+    #[inline]
     fn next_if_name_matches(&mut self, name: &str) -> Option<Span> {
         self.next_if_name_matches(name)
     }
 
+    #[inline]
     fn peek_name(&mut self, n: usize) -> Option<&Name> {
         self.peek_name(n)
     }
 
+    #[inline]
     fn peek_variable_name(&mut self, n: usize) -> bool {
         self.peek_variable_name(n)
     }
 
+    #[inline]
     fn peek_name_matches(&mut self, n: usize, name: &str) -> bool {
         self.peek_name_matches(n, name)
     }
 
+    #[inline]
     fn peek_string_value(&mut self, n: usize) -> bool {
         self.peek_string_value(n)
     }
 
+    #[inline]
     fn peek_punctuator_matches(&mut self, n: usize, punctuator_type: PunctuatorType) -> bool {
         self.peek_punctuator_matches(n, punctuator_type)
     }
 
+    #[inline]
     fn into_errors(self) -> Vec<(LexError, Span)> {
         self.errors
     }

--- a/bluejay-parser/src/lexer/logos_lexer.rs
+++ b/bluejay-parser/src/lexer/logos_lexer.rs
@@ -80,6 +80,7 @@ pub(crate) enum Token<'a> {
     BlockStringValue(Cow<'a, str>),
 }
 
+#[inline]
 fn validate_number_no_trailing_name_start<'a>(
     lexer: &mut logos::Lexer<'a, Token<'a>>,
 ) -> Result<(), LexError> {
@@ -102,6 +103,7 @@ fn validate_number_no_trailing_name_start<'a>(
     }
 }
 
+#[inline]
 fn parse_integer<'a>(lexer: &mut logos::Lexer<'a, Token<'a>>) -> Result<i32, LexError> {
     validate_number_no_trailing_name_start(lexer).and_then(|_| {
         lexer
@@ -111,6 +113,7 @@ fn parse_integer<'a>(lexer: &mut logos::Lexer<'a, Token<'a>>) -> Result<i32, Lex
     })
 }
 
+#[inline]
 fn parse_float<'a>(lexer: &mut logos::Lexer<'a, Token<'a>>) -> Result<f64, LexError> {
     validate_number_no_trailing_name_start(lexer).and_then(|_| {
         lexer
@@ -126,6 +129,7 @@ pub struct LogosLexer<'a>(logos::Lexer<'a, Token<'a>>);
 impl<'a> Iterator for LogosLexer<'a> {
     type Item = Result<LexicalToken<'a>, (LexError, Span)>;
 
+    #[inline]
     fn next(&mut self) -> Option<Self::Item> {
         self.0.next().map(|result| {
             result
@@ -174,6 +178,7 @@ impl<'a> Iterator for LogosLexer<'a> {
     }
 }
 
+#[inline]
 fn punctuator<'a>(pt: PunctuatorType, span: Span) -> LexicalToken<'a> {
     LexicalToken::Punctuator(Punctuator::new(pt, span))
 }

--- a/bluejay-parser/src/span.rs
+++ b/bluejay-parser/src/span.rs
@@ -7,14 +7,17 @@ use std::ops::Add;
 pub struct Span(logos::Span);
 
 impl Span {
+    #[inline]
     pub(crate) fn new(s: logos::Span) -> Self {
         Self(s)
     }
 
+    #[inline]
     pub fn byte_range(&self) -> &std::ops::Range<usize> {
         &self.0
     }
 
+    #[inline]
     pub fn merge(&self, other: &Self) -> Self {
         Self(min(self.0.start, other.0.start)..max(self.0.end, other.0.end))
     }
@@ -38,6 +41,7 @@ impl ariadne::Span for Span {
 }
 
 impl From<logos::Span> for Span {
+    #[inline]
     fn from(value: logos::Span) -> Self {
         Self(value)
     }


### PR DESCRIPTION
The rules applied for something to be marked as inlined is that either a small function or a function with as ingle callsite.

```
parse github schema definitions
                        time:   [3.7500 ms 3.7602 ms 3.7717 ms]
                        change: [-3.6874% -3.3392% -2.9969%] (p = 0.00 < 0.05)
                        Performance has improved.

Benchmarking parse kitchen sink executable document: Collecting 100 samples in estimate
parse kitchen sink executable document
                        time:   [10.215 µs 10.240 µs 10.272 µs]
                        change: [-11.600% -11.267% -10.949%] (p = 0.00 < 0.05)
                        Performance has improved.
```