### PR TITLE
chore(parser): Simplify value discovery

### DIFF
--- a/bluejay-parser/src/ast/variable.rs
+++ b/bluejay-parser/src/ast/variable.rs
@@ -8,6 +8,12 @@ pub struct Variable<'a> {
     span: Span,
 }
 
+impl<'a> Variable<'a> {
+    pub(crate) fn new(name: VariableName<'a>, span: Span) -> Self {
+        Self { name, span }
+    }
+}
+
 impl<'a> IsMatch<'a> for Variable<'a> {
     fn is_match(tokens: &mut impl Tokens<'a>) -> bool {
         tokens.peek_variable_name(0)


### PR DESCRIPTION
this builds on the new variable construct and simplifies the value discovery to a single pass rather than the peek/next iterations.

```
parse github schema definitions
                        time:   [3.8862 ms 3.8934 ms 3.9016 ms]
                        change: [-2.2124% -1.9031% -1.5881%] (p = 0.00 < 0.05)
                        Performance has improved.

Benchmarking parse kitchen sink executable document: Collecting 100 samples in estimate
parse kitchen sink executable document
                        time:   [11.698 µs 11.738 µs 11.778 µs]
                        change: [-2.3241% -2.0186% -1.7033%] (p = 0.00 < 0.05)
                        Performance has improved.
```