### PR TITLE
chore(general): Swap out default hasher in core/parser/validator

### DIFF
--- a/bluejay-core/Cargo.toml
+++ b/bluejay-core/Cargo.toml
@@ -15,6 +15,7 @@ paste = "1.0"
 serde_json = { version = "1.0", optional = true }
 enum-as-inner = "0.6"
 itertools = "0.13.0"
+fnv = "1.0.7"
 
 [features]
 serde_json = ["dep:serde_json"]

--- a/bluejay-core/src/value.rs
+++ b/bluejay-core/src/value.rs
@@ -1,6 +1,6 @@
 use crate::AsIter;
 use enum_as_inner::EnumAsInner;
-use std::collections::HashMap;
+use fnv::FnvHashMap;
 
 #[cfg(feature = "serde_json")]
 mod serde_json;
@@ -93,8 +93,8 @@ impl<'a, const CONST: bool, V: Value<CONST>> std::cmp::PartialEq for ValueRefere
                 matches!(other, Self::List(other_l) if itertools::equal(l.iter().map(Value::as_ref), other_l.iter().map(Value::as_ref)))
             }
             Self::Object(o) => matches!(other, Self::Object(other_o) if {
-                let lhs: HashMap<&str, _> = HashMap::from_iter(o.iter().map(|(k, v)| (k.as_ref(), v.as_ref())));
-                let rhs: HashMap<&str, _> = HashMap::from_iter(other_o.iter().map(|(k, v)| (k.as_ref(), v.as_ref())));
+                let lhs: FnvHashMap<&str, _> = FnvHashMap::from_iter(o.iter().map(|(k, v)| (k.as_ref(), v.as_ref())));
+                let rhs: FnvHashMap<&str, _> = FnvHashMap::from_iter(other_o.iter().map(|(k, v)| (k.as_ref(), v.as_ref())));
                 lhs == rhs
             }),
         }

--- a/bluejay-parser/Cargo.toml
+++ b/bluejay-parser/Cargo.toml
@@ -17,6 +17,7 @@ serde = { version = "1.0.203", optional = true }
 bluejay-core = { version = "0.1.0", path = "../bluejay-core" }
 strum = { version = "0.26", features = ["derive"] }
 itertools = "0.13.0"
+fnv = "1.0.7"
 
 [dev-dependencies]
 criterion = "0.5"

--- a/bluejay-parser/src/ast/definition/definition_document.rs
+++ b/bluejay-parser/src/ast/definition/definition_document.rs
@@ -11,8 +11,9 @@ use bluejay_core::definition::{prelude::*, HasDirectives};
 use bluejay_core::{
     AsIter, BuiltinScalarDefinition, Directive as _, IntoEnumIterator, OperationType,
 };
+use fnv::{FnvHashMap, FnvHashSet};
 use std::collections::btree_map::Entry;
-use std::collections::{BTreeMap, HashMap, HashSet};
+use std::collections::BTreeMap;
 
 mod definition_document_error;
 use definition_document_error::DefinitionDocumentError;
@@ -187,8 +188,8 @@ impl<'a, C: Context> DefinitionDocument<'a, C> {
     /// Inserts builtin scalars only for type names that have not already been parsed
     /// to allow overriding of builtin scalars
     fn insert_builtin_scalar_definitions(&mut self) {
-        let mut builtin_scalars_by_name: HashMap<&str, BuiltinScalarDefinition> =
-            HashMap::from_iter(BuiltinScalarDefinition::iter().map(|bstd| (bstd.name(), bstd)));
+        let mut builtin_scalars_by_name: FnvHashMap<&str, BuiltinScalarDefinition> =
+            FnvHashMap::from_iter(BuiltinScalarDefinition::iter().map(|bstd| (bstd.name(), bstd)));
 
         self.type_definitions.iter().for_each(|td| {
             builtin_scalars_by_name.remove(td.name());
@@ -204,11 +205,13 @@ impl<'a, C: Context> DefinitionDocument<'a, C> {
     /// Inserts builtin directive definitions only for type names that have not already been parsed
     /// to allow optional explicit definition of builtin definitions (since they are optional)
     fn insert_builtin_directive_definitions(&mut self) {
-        let mut builtin_directive_definitions_by_name: HashMap<&str, BuiltinDirectiveDefinition> =
-            HashMap::from_iter(
-                BuiltinDirectiveDefinition::iter()
-                    .map(|bdd: BuiltinDirectiveDefinition| (bdd.into(), bdd)),
-            );
+        let mut builtin_directive_definitions_by_name: FnvHashMap<
+            &str,
+            BuiltinDirectiveDefinition,
+        > = FnvHashMap::from_iter(
+            BuiltinDirectiveDefinition::iter()
+                .map(|bdd: BuiltinDirectiveDefinition| (bdd.into(), bdd)),
+        );
 
         self.directive_definitions().iter().for_each(|dd| {
             builtin_directive_definitions_by_name.remove(dd.name());
@@ -222,7 +225,7 @@ impl<'a, C: Context> DefinitionDocument<'a, C> {
     }
 
     fn add_query_root_fields(&mut self) {
-        let explicit_query_roots: HashSet<&str> = HashSet::from_iter(
+        let explicit_query_roots: FnvHashSet<&str> = FnvHashSet::from_iter(
             self.schema_definitions
                 .iter()
                 .flat_map(|schema_definition| {

--- a/bluejay-parser/src/ast/definition/schema_definition.rs
+++ b/bluejay-parser/src/ast/definition/schema_definition.rs
@@ -13,7 +13,8 @@ use bluejay_core::definition::{
     TypeDefinition as CoreTypeDefinition, TypeDefinitionReference,
 };
 use bluejay_core::AsIter;
-use std::collections::{btree_map::Values, BTreeMap, HashMap};
+use fnv::FnvHashMap;
+use std::collections::{btree_map::Values, BTreeMap};
 
 #[derive(Debug)]
 pub struct SchemaDefinition<'a, C: Context = DefaultContext> {
@@ -24,7 +25,7 @@ pub struct SchemaDefinition<'a, C: Context = DefaultContext> {
     mutation: Option<&'a ObjectTypeDefinition<'a, C>>,
     subscription: Option<&'a ObjectTypeDefinition<'a, C>>,
     directives: Option<&'a Directives<'a, C>>,
-    interface_implementors: HashMap<&'a str, Vec<&'a ObjectTypeDefinition<'a, C>>>,
+    interface_implementors: FnvHashMap<&'a str, Vec<&'a ObjectTypeDefinition<'a, C>>>,
 }
 
 impl<'a, C: Context> SchemaDefinition<'a, C> {
@@ -52,9 +53,9 @@ impl<'a, C: Context> SchemaDefinition<'a, C> {
 
     fn interface_implementors(
         type_definitions: &BTreeMap<&'a str, &'a TypeDefinition<'a, C>>,
-    ) -> HashMap<&'a str, Vec<&'a ObjectTypeDefinition<'a, C>>> {
+    ) -> FnvHashMap<&'a str, Vec<&'a ObjectTypeDefinition<'a, C>>> {
         type_definitions.values().fold(
-            HashMap::new(),
+            FnvHashMap::default(),
             |mut interface_implementors, &type_definition| {
                 if let TypeDefinition::Object(otd) = type_definition {
                     if let Some(interface_implementations) = otd.interface_implementations() {

--- a/bluejay-validator/Cargo.toml
+++ b/bluejay-validator/Cargo.toml
@@ -16,6 +16,7 @@ paste = "1.0"
 itertools = "0.13.0"
 serde_json = { version = "1.0", optional = true }
 seq-macro = "0.3.5"
+fnv = "1.0.7"
 
 [dev-dependencies]
 bluejay-core = { path = "../bluejay-core", features = ["serde_json"] }

--- a/bluejay-validator/src/executable/cache.rs
+++ b/bluejay-validator/src/executable/cache.rs
@@ -4,18 +4,18 @@ use bluejay_core::executable::{
     ExecutableDocument, FragmentDefinition, OperationDefinition, VariableDefinition,
 };
 use bluejay_core::{AsIter, Indexed};
-use std::collections::HashMap;
+use fnv::FnvHashMap;
 
 pub struct Cache<'a, E: ExecutableDocument, S: SchemaDefinition> {
     variable_definition_input_types:
-        HashMap<Indexed<'a, E::VariableType>, VariableDefinitionInputType<'a, S::InputType>>,
-    indexed_fragment_definitions: HashMap<&'a str, &'a E::FragmentDefinition>,
+        FnvHashMap<Indexed<'a, E::VariableType>, VariableDefinitionInputType<'a, S::InputType>>,
+    indexed_fragment_definitions: FnvHashMap<&'a str, &'a E::FragmentDefinition>,
 }
 
 impl<'a, E: ExecutableDocument, S: SchemaDefinition> Cache<'a, E, S> {
     pub fn new(executable_document: &'a E, schema_definition: &'a S) -> Self {
         let variable_definition_input_types =
-            HashMap::from_iter(executable_document.operation_definitions().flat_map(
+        FnvHashMap::from_iter(executable_document.operation_definitions().flat_map(
                 |operation_definition: &'a E::OperationDefinition| {
                     let variable_definitions_iterator = operation_definition
                         .as_ref()
@@ -38,7 +38,7 @@ impl<'a, E: ExecutableDocument, S: SchemaDefinition> Cache<'a, E, S> {
                         })
                 },
             ));
-        let indexed_fragment_definitions = HashMap::from_iter(
+        let indexed_fragment_definitions = FnvHashMap::from_iter(
             executable_document
                 .fragment_definitions()
                 .map(|fragment_definition| (fragment_definition.name(), fragment_definition)),

--- a/bluejay-validator/src/executable/document/rules/all_variable_usages_allowed.rs
+++ b/bluejay-validator/src/executable/document/rules/all_variable_usages_allowed.rs
@@ -11,12 +11,13 @@ use bluejay_core::executable::{
     VariableTypeReference,
 };
 use bluejay_core::{Argument, AsIter, Indexed, ObjectValue, Value, ValueReference, Variable};
+use fnv::FnvHashMap;
 use itertools::Either;
-use std::collections::{BTreeMap, BTreeSet, HashMap};
+use std::collections::{BTreeMap, BTreeSet};
 use std::ops::Not;
 
 pub struct AllVariableUsagesAllowed<'a, E: ExecutableDocument, S: SchemaDefinition> {
-    fragment_references: HashMap<Indexed<'a, E::FragmentDefinition>, BTreeSet<PathRoot<'a, E>>>,
+    fragment_references: FnvHashMap<Indexed<'a, E::FragmentDefinition>, BTreeSet<PathRoot<'a, E>>>,
     variable_usages: BTreeMap<PathRoot<'a, E>, Vec<VariableUsage<'a, E, S>>>,
     cache: &'a Cache<'a, E, S>,
     schema_definition: &'a S,
@@ -27,7 +28,7 @@ impl<'a, E: ExecutableDocument + 'a, S: SchemaDefinition + 'a> Visitor<'a, E, S>
 {
     fn new(_: &'a E, schema_definition: &'a S, cache: &'a Cache<'a, E, S>) -> Self {
         Self {
-            fragment_references: HashMap::new(),
+            fragment_references: FnvHashMap::default(),
             variable_usages: BTreeMap::new(),
             cache,
             schema_definition,

--- a/bluejay-validator/src/executable/document/rules/all_variable_uses_defined.rs
+++ b/bluejay-validator/src/executable/document/rules/all_variable_uses_defined.rs
@@ -7,11 +7,12 @@ use bluejay_core::executable::{
     ExecutableDocument, FragmentSpread, OperationDefinition, VariableDefinition,
 };
 use bluejay_core::{Argument, AsIter, Indexed, ObjectValue, Value, ValueReference, Variable};
+use fnv::FnvHashMap;
 use itertools::Either;
-use std::collections::{BTreeMap, BTreeSet, HashMap};
+use std::collections::{BTreeMap, BTreeSet};
 
 pub struct AllVariableUsesDefined<'a, E: ExecutableDocument, S: SchemaDefinition> {
-    fragment_references: HashMap<Indexed<'a, E::FragmentDefinition>, BTreeSet<PathRoot<'a, E>>>,
+    fragment_references: FnvHashMap<Indexed<'a, E::FragmentDefinition>, BTreeSet<PathRoot<'a, E>>>,
     variable_usages:
         BTreeMap<PathRoot<'a, E>, Vec<&'a <E::Value<false> as Value<false>>::Variable>>,
     cache: &'a Cache<'a, E, S>,
@@ -22,7 +23,7 @@ impl<'a, E: ExecutableDocument + 'a, S: SchemaDefinition + 'a> Visitor<'a, E, S>
 {
     fn new(_: &'a E, _: &'a S, cache: &'a Cache<'a, E, S>) -> Self {
         Self {
-            fragment_references: HashMap::new(),
+            fragment_references: FnvHashMap::default(),
             variable_usages: BTreeMap::new(),
             cache,
         }

--- a/bluejay-validator/src/executable/document/rules/required_arguments.rs
+++ b/bluejay-validator/src/executable/document/rules/required_arguments.rs
@@ -7,7 +7,7 @@ use bluejay_core::definition::{
 };
 use bluejay_core::executable::{ExecutableDocument, Field};
 use bluejay_core::{Argument, AsIter, Directive};
-use std::collections::HashMap;
+use fnv::FnvHashMap;
 
 pub struct RequiredArguments<'a, E: ExecutableDocument, S: SchemaDefinition> {
     schema_definition: &'a S,
@@ -54,8 +54,8 @@ impl<'a, E: ExecutableDocument + 'a, S: SchemaDefinition + 'a> RequiredArguments
             let indexed_arguments = arguments
                 .map(|arguments| {
                     arguments.iter().fold(
-                        HashMap::new(),
-                        |mut indexed_arguments: HashMap<&'a str, &'a E::Argument<CONST>>,
+                        FnvHashMap::default(),
+                        |mut indexed_arguments: FnvHashMap<&'a str, &'a E::Argument<CONST>>,
                          argument| {
                             indexed_arguments.insert(argument.name(), argument);
                             indexed_arguments

--- a/bluejay-validator/src/executable/operation/analyzers/complexity_cost.rs
+++ b/bluejay-validator/src/executable/operation/analyzers/complexity_cost.rs
@@ -8,9 +8,9 @@ use bluejay_core::definition::{
 };
 use bluejay_core::executable::{ExecutableDocument, Field};
 use bluejay_core::AsIter;
+use fnv::FnvHashMap;
 use itertools::{Either, Itertools};
 use std::cmp::max;
-use std::collections::HashMap;
 
 mod arena;
 use arena::{Arena, NodeId};
@@ -111,7 +111,7 @@ impl<
             .entry(scoped_type.name())
             .or_insert_with(|| TypedSelection {
                 type_definition: scoped_type,
-                inner_selection: HashMap::new(),
+                inner_selection: FnvHashMap::default(),
             })
             .inner_selection
             .entry(field_key)
@@ -301,7 +301,7 @@ impl<
     }
 }
 
-type InnerSelection<'a> = HashMap<&'a str, NodeId>;
+type InnerSelection<'a> = FnvHashMap<&'a str, NodeId>;
 
 struct TypedSelection<'a, T: TypeDefinition> {
     type_definition: TypeDefinitionReference<'a, T>,
@@ -311,7 +311,7 @@ struct TypedSelection<'a, T: TypeDefinition> {
 struct ComplexityScope<'a, T: TypeDefinition, F> {
     cost: usize,
     multiplier: usize,
-    typed_selections: HashMap<&'a str, TypedSelection<'a, T>>,
+    typed_selections: FnvHashMap<&'a str, TypedSelection<'a, T>>,
     field_multipliers: F,
 }
 
@@ -320,7 +320,7 @@ impl<'a, T: TypeDefinition, F: Default> Default for ComplexityScope<'a, T, F> {
         Self {
             cost: 0,
             multiplier: 1,
-            typed_selections: HashMap::new(),
+            typed_selections: FnvHashMap::default(),
             field_multipliers: F::default(),
         }
     }

--- a/bluejay-validator/src/executable/operation/analyzers/variable_values_are_valid.rs
+++ b/bluejay-validator/src/executable/operation/analyzers/variable_values_are_valid.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use fnv::FnvHashMap;
 use std::marker::PhantomData;
 
 use crate::{
@@ -19,7 +19,7 @@ pub struct VariableValuesAreValid<
 > {
     executable_document: PhantomData<E>,
     schema_definition: &'a S,
-    indexed_variable_values: HashMap<&'a str, (&'a VV::Key, &'a VV::Value)>,
+    indexed_variable_values: FnvHashMap<&'a str, (&'a VV::Key, &'a VV::Value)>,
     cache: &'a Cache<'a, E, S>,
     errors: Vec<VariableValueError<'a, E, VV>>,
 }


### PR DESCRIPTION
General improvements ranging from 8-20%, I'll apply this now to the rest of our validation.

```
Benchmarking field_selection_merging/1: Collecting 100 samples in estimated 5.0089 s (2
field_selection_merging/1
                        time:   [2.3106 µs 2.3397 µs 2.3702 µs]
                        thrpt:  [421.91 Kelem/s 427.40 Kelem/s 432.78 Kelem/s]
                 change:
                        time:   [-20.254% -16.823% -13.953%] (p = 0.00 < 0.05)
                        thrpt:  [+16.215% +20.226% +25.397%]
                        Performance has improved.

Benchmarking field_selection_merging/2: Collecting 100 samples in estimated 5.0083 s (5
field_selection_merging/2
                        time:   [9.9452 µs 9.9973 µs 10.058 µs]
                        thrpt:  [198.85 Kelem/s 200.05 Kelem/s 201.10 Kelem/s]
                 change:
                        time:   [-16.537% -15.898% -15.308%] (p = 0.00 < 0.05)
                        thrpt:  [+18.075% +18.903% +19.814%]
                        Performance has improved.

Benchmarking field_selection_merging/4: Collecting 100 samples in estimated 5.0198 s (2
field_selection_merging/4
                        time:   [18.670 µs 18.743 µs 18.818 µs]
                        thrpt:  [212.56 Kelem/s 213.41 Kelem/s 214.24 Kelem/s]
                 change:
                        time:   [-13.374% -12.690% -12.086%] (p = 0.00 < 0.05)
                        thrpt:  [+13.748% +14.534% +15.439%]
                        Performance has improved.

Benchmarking field_selection_merging/8: Collecting 100 samples in estimated 5.1048 s (1
field_selection_merging/8
                        time:   [37.476 µs 37.584 µs 37.695 µs]
                        thrpt:  [212.23 Kelem/s 212.86 Kelem/s 213.47 Kelem/s]
                 change:
                        time:   [-11.802% -11.416% -11.041%] (p = 0.00 < 0.05)
                        thrpt:  [+12.411% +12.887% +13.382%]
                        Performance has improved.

Benchmarking field_selection_merging/16: Collecting 100 samples in estimated 5.2224 s (
field_selection_merging/16
                        time:   [74.449 µs 74.684 µs 74.935 µs]
                        thrpt:  [213.52 Kelem/s 214.24 Kelem/s 214.91 Kelem/s]
                 change:
                        time:   [-9.9588% -8.9481% -8.0580%] (p = 0.00 < 0.05)
                        thrpt:  [+8.7642% +9.8274% +11.060%]
                        Performance has improved.

Benchmarking field_selection_merging/32: Collecting 100 samples in estimated 5.1257 s (
field_selection_merging/32
                        time:   [143.27 µs 143.89 µs 144.57 µs]
                        thrpt:  [221.35 Kelem/s 222.39 Kelem/s 223.35 Kelem/s]
                 change:
                        time:   [-8.3642% -7.9132% -7.4810%] (p = 0.00 < 0.05)
                        thrpt:  [+8.0859% +8.5932% +9.1276%]
                        Performance has improved.

Benchmarking field_selection_merging/64: Collecting 100 samples in estimated 5.8019 s (
field_selection_merging/64
                        time:   [288.93 µs 292.61 µs 296.89 µs]
                        thrpt:  [215.57 Kelem/s 218.72 Kelem/s 221.51 Kelem/s]
                 change:
                        time:   [-6.3697% -5.6095% -4.8101%] (p = 0.00 < 0.05)
                        thrpt:  [+5.0532% +5.9428% +6.8030%]
                        Performance has improved.

Benchmarking field_selection_merging/128: Collecting 100 samples in estimated 5.7565 s 
field_selection_merging/128
                        time:   [559.57 µs 562.11 µs 565.11 µs]
                        thrpt:  [226.50 Kelem/s 227.72 Kelem/s 228.75 Kelem/s]
                 change:
                        time:   [-9.4958% -8.9954% -8.4677%] (p = 0.00 < 0.05)
                        thrpt:  [+9.2511% +9.8846% +10.492%]
                        Performance has improved.
```