### PR TITLE
chore(parser): Improve error msg

### DIFF
--- a/bluejay-parser/src/lexer/lex_error.rs
+++ b/bluejay-parser/src/lexer/lex_error.rs
@@ -42,7 +42,7 @@ impl From<(LexError, Span)> for Error {
             ),
             LexError::StringValueInvalid(errors) => Self::new(
                 "String value invalid",
-                Some(Annotation::new("String value", span)),
+                Some(Annotation::new("String value invalid", span)),
                 errors
                     .into_iter()
                     .map(|error| {


### PR DESCRIPTION
After investigating the conversion from our annotation based errors to graphql errors I noticed that some were a bit lacking like the corrected one. There was one alternative approach to always use the over-arching error.message, however in the case of a [`ParseError`](https://github.com/Shopify/bluejay/blob/main/bluejay-parser/src/ast/parse_error.rs#L30) that would then become confusing.