### PR TITLE
Format errors with filename

### DIFF
--- a/bluejay-parser/src/span.rs
+++ b/bluejay-parser/src/span.rs
@@ -1,6 +1,6 @@
 use std::cmp::{max, min};
 use std::cmp::{Ord, Ordering, PartialOrd};
-use std::ops::Add;
+use std::ops::{Add, Range};
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 #[repr(transparent)]
@@ -13,7 +13,7 @@ impl Span {
     }
 
     #[inline]
-    pub fn byte_range(&self) -> &std::ops::Range<usize> {
+    pub fn byte_range(&self) -> &Range<usize> {
         &self.0
     }
 
@@ -23,20 +23,9 @@ impl Span {
     }
 }
 
-#[cfg(feature = "format-errors")]
-impl ariadne::Span for Span {
-    type SourceId = ();
-
-    fn source(&self) -> &Self::SourceId {
-        &()
-    }
-
-    fn start(&self) -> usize {
-        self.0.start
-    }
-
-    fn end(&self) -> usize {
-        self.0.end
+impl From<Span> for Range<usize> {
+    fn from(val: Span) -> Self {
+        val.0
     }
 }
 

--- a/bluejay-parser/tests/executable_document_integration_test.rs
+++ b/bluejay-parser/tests/executable_document_integration_test.rs
@@ -13,7 +13,11 @@ fn test_error() {
             "Document did not have any errors"
         );
         let errors = executable_document.unwrap_err();
-        let formatted_errors = Error::format_errors(input.as_str(), errors);
+        let formatted_errors = Error::format_errors(
+            input.as_str(),
+            path.file_name().and_then(|f| f.to_str()),
+            errors,
+        );
         insta::assert_snapshot!(formatted_errors);
     });
 }

--- a/bluejay-parser/tests/schema_definition_integration_test.rs
+++ b/bluejay-parser/tests/schema_definition_integration_test.rs
@@ -19,7 +19,11 @@ fn test_error() {
             },
             Err(errors) => errors,
         };
-        let formatted_errors = Error::format_errors(input.as_str(), errors);
+        let formatted_errors = Error::format_errors(
+            input.as_str(),
+            path.file_name().and_then(|f| f.to_str()),
+            errors,
+        );
         insta::assert_snapshot!(formatted_errors);
     });
 }

--- a/bluejay-parser/tests/snapshots/executable_document_integration_test__error@empty_arguments.graphql.snap
+++ b/bluejay-parser/tests/snapshots/executable_document_integration_test__error@empty_arguments.graphql.snap
@@ -4,10 +4,9 @@ expression: formatted_errors
 input_file: bluejay-parser/tests/test_data/executable_document/error/empty_arguments.graphql
 ---
 Error: Parse error
-   ╭─[<unknown>:2:9]
+   ╭─[empty_arguments.graphql:2:9]
    │
  2 │   field()
    │         ┬  
    │         ╰── Expected a name
 ───╯
-

--- a/bluejay-parser/tests/snapshots/executable_document_integration_test__error@empty_selection_set.graphql.snap
+++ b/bluejay-parser/tests/snapshots/executable_document_integration_test__error@empty_selection_set.graphql.snap
@@ -4,10 +4,9 @@ expression: formatted_errors
 input_file: bluejay-parser/tests/test_data/executable_document/error/empty_selection_set.graphql
 ---
 Error: Unexpected token
-   ╭─[<unknown>:1:2]
+   ╭─[empty_selection_set.graphql:1:2]
    │
  1 │ {}
    │  ┬  
    │  ╰── Unexpected token
 ───╯
-

--- a/bluejay-parser/tests/snapshots/executable_document_integration_test__error@empty_variables_definition.graphql.snap
+++ b/bluejay-parser/tests/snapshots/executable_document_integration_test__error@empty_variables_definition.graphql.snap
@@ -4,10 +4,9 @@ expression: formatted_errors
 input_file: bluejay-parser/tests/test_data/executable_document/error/empty_variables_definition.graphql
 ---
 Error: Parse error
-   ╭─[<unknown>:1:13]
+   ╭─[empty_variables_definition.graphql:1:13]
    │
  1 │ query Query() {
    │             ┬  
    │             ╰── Expected to find: $
 ───╯
-

--- a/bluejay-parser/tests/snapshots/executable_document_integration_test__error@operation_name_typo.graphql.snap
+++ b/bluejay-parser/tests/snapshots/executable_document_integration_test__error@operation_name_typo.graphql.snap
@@ -4,10 +4,9 @@ expression: formatted_errors
 input_file: bluejay-parser/tests/test_data/executable_document/error/operation_name_typo.graphql
 ---
 Error: Unexpected token
-   ╭─[<unknown>:1:1]
+   ╭─[operation_name_typo.graphql:1:1]
    │
  1 │ querry {
    │ ───┬──  
    │    ╰──── Unexpected token
 ───╯
-

--- a/bluejay-parser/tests/snapshots/executable_document_integration_test__error@unclosed_selection_set.graphql.snap
+++ b/bluejay-parser/tests/snapshots/executable_document_integration_test__error@unclosed_selection_set.graphql.snap
@@ -4,10 +4,9 @@ expression: formatted_errors
 input_file: bluejay-parser/tests/test_data/executable_document/error/unclosed_selection_set.graphql
 ---
 Error: Parse error
-   ╭─[<unknown>:2:9]
+   ╭─[unclosed_selection_set.graphql:2:9]
    │
  2 │   field
    │         │ 
    │         ╰─ Unexpected EOF
 ───╯
-

--- a/bluejay-parser/tests/snapshots/schema_definition_integration_test__error@duplicate_directive_definitions.graphql.snap
+++ b/bluejay-parser/tests/snapshots/schema_definition_integration_test__error@duplicate_directive_definitions.graphql.snap
@@ -4,7 +4,7 @@ expression: formatted_errors
 input_file: bluejay-parser/tests/test_data/schema_definition/error/duplicate_directive_definitions.graphql
 ---
 Error: Multiple directive definitions with name `@foo`
-   ╭─[<unknown>:1:1]
+   ╭─[duplicate_directive_definitions.graphql:1:1]
    │
  1 │ directive @foo on OBJECT
    │            ─┬─  
@@ -14,4 +14,3 @@ Error: Multiple directive definitions with name `@foo`
    │            ─┬─  
    │             ╰─── Directive definition with name `@foo`
 ───╯
-

--- a/bluejay-parser/tests/snapshots/schema_definition_integration_test__error@duplicate_root_operation_definitions.graphql.snap
+++ b/bluejay-parser/tests/snapshots/schema_definition_integration_test__error@duplicate_root_operation_definitions.graphql.snap
@@ -4,7 +4,7 @@ expression: formatted_errors
 input_file: bluejay-parser/tests/test_data/schema_definition/error/duplicate_root_operation_definitions.graphql
 ---
 Error: Multiple root operation type definitions for `query`
-    ╭─[<unknown>:1:1]
+    ╭─[duplicate_root_operation_definitions.graphql:1:1]
     │
  10 │   query: MyObject
     │          ────┬───  
@@ -13,4 +13,3 @@ Error: Multiple root operation type definitions for `query`
     │          ──────┬──────  
     │                ╰──────── Root operation type definition for `query`
 ────╯
-

--- a/bluejay-parser/tests/snapshots/schema_definition_integration_test__error@duplicate_schema_definitions.graphql.snap
+++ b/bluejay-parser/tests/snapshots/schema_definition_integration_test__error@duplicate_schema_definitions.graphql.snap
@@ -4,7 +4,7 @@ expression: formatted_errors
 input_file: bluejay-parser/tests/test_data/schema_definition/error/duplicate_schema_definitions.graphql
 ---
 Error: Multiple schema definitions
-   ╭─[<unknown>:1:1]
+   ╭─[duplicate_schema_definitions.graphql:1:1]
    │
  5 │ schema {
    │ ───┬──  
@@ -14,4 +14,3 @@ Error: Multiple schema definitions
    │ ───┬──  
    │    ╰──── Schema definition
 ───╯
-

--- a/bluejay-parser/tests/snapshots/schema_definition_integration_test__error@duplicate_type_definitions.graphql.snap
+++ b/bluejay-parser/tests/snapshots/schema_definition_integration_test__error@duplicate_type_definitions.graphql.snap
@@ -4,7 +4,7 @@ expression: formatted_errors
 input_file: bluejay-parser/tests/test_data/schema_definition/error/duplicate_type_definitions.graphql
 ---
 Error: Multiple type definitions with name `Query`
-   ╭─[<unknown>:1:1]
+   ╭─[duplicate_type_definitions.graphql:1:1]
    │
  4 │ type Query {
    │      ──┬──  
@@ -14,4 +14,3 @@ Error: Multiple type definitions with name `Query`
    │      ──┬──  
    │        ╰──── Type definition with name `Query`
 ───╯
-

--- a/bluejay-parser/tests/snapshots/schema_definition_integration_test__error@explicit_root_operation_type_does_not_exist.graphql.snap
+++ b/bluejay-parser/tests/snapshots/schema_definition_integration_test__error@explicit_root_operation_type_does_not_exist.graphql.snap
@@ -4,10 +4,9 @@ expression: formatted_errors
 input_file: bluejay-parser/tests/test_data/schema_definition/error/explicit_root_operation_type_does_not_exist.graphql
 ---
 Error: Referenced type `DoesNotExist` does not exist
-   ╭─[<unknown>:2:10]
+   ╭─[explicit_root_operation_type_does_not_exist.graphql:2:10]
    │
  2 │   query: DoesNotExist
    │          ──────┬─────  
    │                ╰─────── No definition for referenced type
 ───╯
-

--- a/bluejay-parser/tests/snapshots/schema_definition_integration_test__error@explicit_root_operation_type_not_an_object.graphql.snap
+++ b/bluejay-parser/tests/snapshots/schema_definition_integration_test__error@explicit_root_operation_type_not_an_object.graphql.snap
@@ -4,10 +4,9 @@ expression: formatted_errors
 input_file: bluejay-parser/tests/test_data/schema_definition/error/explicit_root_operation_type_not_an_object.graphql
 ---
 Error: Referenced type `Int` is not an object
-   ╭─[<unknown>:2:10]
+   ╭─[explicit_root_operation_type_not_an_object.graphql:2:10]
    │
  2 │   query: Int
    │          ─┬─  
    │           ╰─── Not an object type
 ───╯
-

--- a/bluejay-parser/tests/snapshots/schema_definition_integration_test__error@explicit_schema_definition_missing_query.graphql.snap
+++ b/bluejay-parser/tests/snapshots/schema_definition_integration_test__error@explicit_schema_definition_missing_query.graphql.snap
@@ -4,7 +4,7 @@ expression: formatted_errors
 input_file: bluejay-parser/tests/test_data/schema_definition/error/explicit_schema_definition_missing_query.graphql
 ---
 Error: Schema definition does not contain a query
-   ╭─[<unknown>:5:8]
+   ╭─[explicit_schema_definition_missing_query.graphql:5:8]
    │
  5 │ ╭─▶ schema {
    ┆ ┆   
@@ -12,4 +12,3 @@ Error: Schema definition does not contain a query
    │ │       
    │ ╰─────── Does not contain a query
 ───╯
-

--- a/bluejay-parser/tests/snapshots/schema_definition_integration_test__error@implicit_root_operation_type_not_an_object.graphql.snap
+++ b/bluejay-parser/tests/snapshots/schema_definition_integration_test__error@implicit_root_operation_type_not_an_object.graphql.snap
@@ -4,10 +4,9 @@ expression: formatted_errors
 input_file: bluejay-parser/tests/test_data/schema_definition/error/implicit_root_operation_type_not_an_object.graphql
 ---
 Error: Referenced type `Query` is not an object
-   ╭─[<unknown>:1:7]
+   ╭─[implicit_root_operation_type_not_an_object.graphql:1:7]
    │
  1 │ input Query {
    │       ──┬──  
    │         ╰──── Not an object type
 ───╯
-

--- a/bluejay-parser/tests/snapshots/schema_definition_integration_test__error@redefine_builtin_type_definition.graphql.snap
+++ b/bluejay-parser/tests/snapshots/schema_definition_integration_test__error@redefine_builtin_type_definition.graphql.snap
@@ -4,10 +4,9 @@ expression: formatted_errors
 input_file: bluejay-parser/tests/test_data/schema_definition/error/redefine_builtin_type_definition.graphql
 ---
 Error: Cannot redefine builtin type __Schema
-   ╭─[<unknown>:1:1]
+   ╭─[redefine_builtin_type_definition.graphql:1:1]
    │
  1 │ type __Schema {
    │      ────┬───  
    │          ╰───── Type definition with name `__Schema`
 ───╯
-

--- a/bluejay-parser/tests/snapshots/schema_definition_integration_test__error@referenced_directive_does_not_exist.graphql.snap
+++ b/bluejay-parser/tests/snapshots/schema_definition_integration_test__error@referenced_directive_does_not_exist.graphql.snap
@@ -4,10 +4,9 @@ expression: formatted_errors
 input_file: bluejay-parser/tests/test_data/schema_definition/error/referenced_directive_does_not_exist.graphql
 ---
 Error: Referenced directive `@foo` does not exist
-   ╭─[<unknown>:1:12]
+   ╭─[referenced_directive_does_not_exist.graphql:1:12]
    │
  1 │ type Query @foo {
    │            ──┬─  
    │              ╰─── No definition for referenced directive
 ───╯
-

--- a/bluejay-parser/tests/snapshots/schema_definition_integration_test__error@referenced_type_does_not_exist.graphql.snap
+++ b/bluejay-parser/tests/snapshots/schema_definition_integration_test__error@referenced_type_does_not_exist.graphql.snap
@@ -4,7 +4,7 @@ expression: formatted_errors
 input_file: bluejay-parser/tests/test_data/schema_definition/error/referenced_type_does_not_exist.graphql
 ---
 Error: Referenced type `TypeDoesNotExist` does not exist
-   ╭─[<unknown>:2:11]
+   ╭─[referenced_type_does_not_exist.graphql:2:11]
    │
  2 │   field1: TypeDoesNotExist!
    │           ────────┬───────  
@@ -12,10 +12,9 @@ Error: Referenced type `TypeDoesNotExist` does not exist
 ───╯
 
 Error: Referenced type `TypeAlsoDoesNotExist` does not exist
-   ╭─[<unknown>:3:11]
+   ╭─[referenced_type_does_not_exist.graphql:3:11]
    │
  3 │   field2: TypeAlsoDoesNotExist!
    │           ──────────┬─────────  
    │                     ╰─────────── No definition for referenced type
 ───╯
-

--- a/bluejay-parser/tests/snapshots/schema_definition_integration_test__error@referenced_type_is_not_an_input_type.graphql.snap
+++ b/bluejay-parser/tests/snapshots/schema_definition_integration_test__error@referenced_type_is_not_an_input_type.graphql.snap
@@ -4,10 +4,9 @@ expression: formatted_errors
 input_file: bluejay-parser/tests/test_data/schema_definition/error/referenced_type_is_not_an_input_type.graphql
 ---
 Error: Referenced type `MyObject` is not an input type
-   ╭─[<unknown>:6:19]
+   ╭─[referenced_type_is_not_an_input_type.graphql:6:19]
    │
  6 │   field(myObject: MyObject!): Int!
    │                   ────┬───  
    │                       ╰───── Not an input type
 ───╯
-

--- a/bluejay-parser/tests/snapshots/schema_definition_integration_test__error@referenced_type_is_not_an_interface.graphql.snap
+++ b/bluejay-parser/tests/snapshots/schema_definition_integration_test__error@referenced_type_is_not_an_interface.graphql.snap
@@ -4,10 +4,9 @@ expression: formatted_errors
 input_file: bluejay-parser/tests/test_data/schema_definition/error/referenced_type_is_not_an_interface.graphql
 ---
 Error: Referenced type `MyObject` is not an interface
-   ╭─[<unknown>:5:31]
+   ╭─[referenced_type_is_not_an_interface.graphql:5:31]
    │
  5 │ type MyOtherObject implements MyObject {
    │                               ────┬───  
    │                                   ╰───── Not an interface
 ───╯
-

--- a/bluejay-parser/tests/snapshots/schema_definition_integration_test__error@referenced_type_is_not_an_output_type.graphql.snap
+++ b/bluejay-parser/tests/snapshots/schema_definition_integration_test__error@referenced_type_is_not_an_output_type.graphql.snap
@@ -4,10 +4,9 @@ expression: formatted_errors
 input_file: bluejay-parser/tests/test_data/schema_definition/error/referenced_type_is_not_an_output_type.graphql
 ---
 Error: Referenced type `MyInput` is not an output type
-   ╭─[<unknown>:6:12]
+   ╭─[referenced_type_is_not_an_output_type.graphql:6:12]
    │
  6 │   myField: MyInput!
    │            ───┬───  
    │               ╰───── Not an output type
 ───╯
-

--- a/bluejay-parser/tests/snapshots/schema_definition_integration_test__error@referenced_union_member_type_is_not_an_object.graphql.snap
+++ b/bluejay-parser/tests/snapshots/schema_definition_integration_test__error@referenced_union_member_type_is_not_an_object.graphql.snap
@@ -4,7 +4,7 @@ expression: formatted_errors
 input_file: bluejay-parser/tests/test_data/schema_definition/error/referenced_union_member_type_is_not_an_object.graphql
 ---
 Error: Referenced type `Int` is not an object
-   ╭─[<unknown>:1:17]
+   ╭─[referenced_union_member_type_is_not_an_object.graphql:1:17]
    │
  1 │ union MyUnion = Int | String
    │                 ─┬─  
@@ -12,10 +12,9 @@ Error: Referenced type `Int` is not an object
 ───╯
 
 Error: Referenced type `String` is not an object
-   ╭─[<unknown>:1:23]
+   ╭─[referenced_union_member_type_is_not_an_object.graphql:1:23]
    │
  1 │ union MyUnion = Int | String
    │                       ───┬──  
    │                          ╰──── Not an object type
 ───╯
-

--- a/bluejay-parser/tests/snapshots/schema_definition_integration_test__error@reserved_keyword_enum_value.graphql.snap
+++ b/bluejay-parser/tests/snapshots/schema_definition_integration_test__error@reserved_keyword_enum_value.graphql.snap
@@ -4,7 +4,7 @@ expression: formatted_errors
 input_file: bluejay-parser/tests/test_data/schema_definition/error/reserved_keyword_enum_value.graphql
 ---
 Error: Parse error
-   ╭─[<unknown>:2:3]
+   ╭─[reserved_keyword_enum_value.graphql:2:3]
    │
  2 │   true
    │   ──┬─  

--- a/bluejay-typegen-macro/src/input.rs
+++ b/bluejay-typegen-macro/src/input.rs
@@ -74,10 +74,12 @@ impl ToTokens for DocumentInput {
 }
 
 impl DocumentInput {
-    pub(crate) fn read_to_string(&self) -> syn::Result<String> {
+    pub(crate) fn read_to_string_and_path(&self) -> syn::Result<(String, Option<String>)> {
         match self {
-            Self::Path(path) => Self::read_file(path),
-            Self::Dsl { contents, .. } => Ok(contents.to_string()),
+            Self::Path(path) => {
+                Self::read_file(path).map(|contents| (contents, Some(path.value())))
+            }
+            Self::Dsl { contents, .. } => Ok((contents.to_string(), None)),
         }
     }
 

--- a/bluejay-validator/tests/combine_executable_rules_test.rs
+++ b/bluejay-validator/tests/combine_executable_rules_test.rs
@@ -36,6 +36,6 @@ fn test_combine_executable_rules() {
     assert!(
         errors.is_empty(),
         "Document had validation errors:\n{}",
-        Error::format_errors(executable_document_str, errors),
+        Error::format_errors(executable_document_str, None, errors),
     )
 }

--- a/bluejay-validator/tests/definition_integration_test.rs
+++ b/bluejay-validator/tests/definition_integration_test.rs
@@ -18,7 +18,8 @@ fn test_error() {
 
         let errors: Vec<_> = BuiltinRulesValidator::validate(&schema_definition).collect();
 
-        let formatted_errors = Error::format_errors(&input, errors);
+        let formatted_errors =
+            Error::format_errors(&input, path.file_name().and_then(|f| f.to_str()), errors);
         insta::assert_snapshot!(formatted_errors);
     });
 }
@@ -38,7 +39,7 @@ fn test_valid() {
             errors.is_empty(),
             "Schema `{}` had validation errors:\n{}",
             path.display(),
-            Error::format_errors(&input, errors),
+            Error::format_errors(&input, path.file_name().and_then(|f| f.to_str()), errors),
         )
     });
 }

--- a/bluejay-validator/tests/executable_integration_test.rs
+++ b/bluejay-validator/tests/executable_integration_test.rs
@@ -18,7 +18,11 @@ fn test_error() {
             let cache = Cache::new(&executable_document, &schema_definition);
             let errors =
                 BuiltinRulesValidator::validate(&executable_document, &schema_definition, &cache);
-            let formatted_errors = Error::format_errors(input.as_str(), errors);
+            let formatted_errors = Error::format_errors(
+                input.as_str(),
+                path.file_name().and_then(|f| f.to_str()),
+                errors,
+            );
             insta::assert_snapshot!(formatted_errors);
         });
     });
@@ -39,7 +43,11 @@ fn test_valid() {
                 errors.is_empty(),
                 "Document `{}` had validation errors:\n{}",
                 path.display(),
-                Error::format_errors(input.as_str(), errors),
+                Error::format_errors(
+                    input.as_str(),
+                    path.file_name().and_then(|f| f.to_str()),
+                    errors
+                ),
             )
         });
     });

--- a/bluejay-validator/tests/snapshots/definition_integration_test__error@enum_value_definition_uniqueness.graphql.snap
+++ b/bluejay-validator/tests/snapshots/definition_integration_test__error@enum_value_definition_uniqueness.graphql.snap
@@ -4,7 +4,7 @@ expression: formatted_errors
 input_file: bluejay-validator/tests/test_data/definition/error/enum_value_definition_uniqueness.graphql
 ---
 Error: Multiple enum value definitions named `VARIANT_1`
-   ╭─[<unknown>:1:1]
+   ╭─[enum_value_definition_uniqueness.graphql:1:1]
    │
  2 │   VARIANT_1
    │   ────┬────  
@@ -14,4 +14,3 @@ Error: Multiple enum value definitions named `VARIANT_1`
    │   ────┬────  
    │       ╰────── Enum value definition with name `VARIANT_1`
 ───╯
-

--- a/bluejay-validator/tests/snapshots/definition_integration_test__error@input_object_circular_references.graphql.snap
+++ b/bluejay-validator/tests/snapshots/definition_integration_test__error@input_object_circular_references.graphql.snap
@@ -4,7 +4,7 @@ expression: formatted_errors
 input_file: bluejay-validator/tests/test_data/definition/error/input_object_circular_references.graphql
 ---
 Error: Input object type definition `MyInput` contains disallowed circular reference(s)
-   ╭─[<unknown>:1:7]
+   ╭─[input_object_circular_references.graphql:1:7]
    │
  1 │ input MyInput {
    │       ───┬───  
@@ -19,7 +19,7 @@ Error: Input object type definition `MyInput` contains disallowed circular refer
 ───╯
 
 Error: Input object type definition `NestedInput` contains disallowed circular reference(s)
-   ╭─[<unknown>:6:7]
+   ╭─[input_object_circular_references.graphql:6:7]
    │
  3 │   nestedCircularReference: NestedInput!
    │                            ──────┬─────  
@@ -29,4 +29,3 @@ Error: Input object type definition `NestedInput` contains disallowed circular r
    │       ─────┬─────  
    │            ╰─────── Input object type definition contains circular reference(s) through an unbroken chain of non-null singular fields, which is disallowed
 ───╯
-

--- a/bluejay-validator/tests/snapshots/definition_integration_test__error@input_value_definition_uniqueness.graphql.snap
+++ b/bluejay-validator/tests/snapshots/definition_integration_test__error@input_value_definition_uniqueness.graphql.snap
@@ -4,7 +4,7 @@ expression: formatted_errors
 input_file: bluejay-validator/tests/test_data/definition/error/input_value_definition_uniqueness.graphql
 ---
 Error: Multiple input value definitions named `arg1`
-   ╭─[<unknown>:1:1]
+   ╭─[input_value_definition_uniqueness.graphql:1:1]
    │
  2 │   arg1: String
    │   ──┬─  
@@ -14,4 +14,3 @@ Error: Multiple input value definitions named `arg1`
    │   ──┬─  
    │     ╰─── Input value definition with name `arg1`
 ───╯
-

--- a/bluejay-validator/tests/snapshots/executable_integration_test__error@all_variable_usages_allowed.graphql.snap
+++ b/bluejay-validator/tests/snapshots/executable_integration_test__error@all_variable_usages_allowed.graphql.snap
@@ -4,7 +4,7 @@ expression: formatted_errors
 input_file: bluejay-validator/tests/test_data/executable/error/all_variable_usages_allowed.graphql
 ---
 Error: Variable $intArg of type Int cannot be used here, where Boolean is expected
-   ╭─[<unknown>:3:33]
+   ╭─[all_variable_usages_allowed.graphql:3:33]
    │
  3 │     booleanArgField(booleanArg: $intArg)
    │                                 ───┬───  
@@ -12,7 +12,7 @@ Error: Variable $intArg of type Int cannot be used here, where Boolean is expect
 ───╯
 
 Error: Variable $booleanListArg of type [Boolean] cannot be used here, where Boolean is expected
-   ╭─[<unknown>:9:33]
+   ╭─[all_variable_usages_allowed.graphql:9:33]
    │
  9 │     booleanArgField(booleanArg: $booleanListArg)
    │                                 ───────┬───────  
@@ -20,7 +20,7 @@ Error: Variable $booleanListArg of type [Boolean] cannot be used here, where Boo
 ───╯
 
 Error: Variable $booleanArg of type Boolean cannot be used here, where Boolean! is expected
-    ╭─[<unknown>:15:47]
+    ╭─[all_variable_usages_allowed.graphql:15:47]
     │
  15 │     nonNullBooleanArgField(nonNullBooleanArg: $booleanArg)
     │                                               ─────┬─────  
@@ -28,10 +28,9 @@ Error: Variable $booleanArg of type Boolean cannot be used here, where Boolean! 
 ────╯
 
 Error: Variable $booleanList of type [Boolean] cannot be used here, where [Boolean!] is expected
-    ╭─[<unknown>:21:52]
+    ╭─[all_variable_usages_allowed.graphql:21:52]
     │
  21 │     nonNullBooleanListField(nonNullBooleanListArg: $booleanList)
     │                                                    ──────┬─────  
     │                                                          ╰─────── Cannot use variable of type [Boolean] where [Boolean!] is expected
 ────╯
-

--- a/bluejay-validator/tests/snapshots/executable_integration_test__error@all_variable_uses_defined.graphql.snap
+++ b/bluejay-validator/tests/snapshots/executable_integration_test__error@all_variable_uses_defined.graphql.snap
@@ -4,7 +4,7 @@ expression: formatted_errors
 input_file: bluejay-validator/tests/test_data/executable/error/all_variable_uses_defined.graphql
 ---
 Error: Variable $atOtherHomes not defined in operation variableIsNotDefined
-   ╭─[<unknown>:3:34]
+   ╭─[all_variable_uses_defined.graphql:3:34]
    │
  3 │     isHouseTrained(atOtherHomes: $atOtherHomes)
    │                                  ──────┬──────  
@@ -12,7 +12,7 @@ Error: Variable $atOtherHomes not defined in operation variableIsNotDefined
 ───╯
 
 Error: Variable $atOtherHomes not defined in operation variableIsNotDefinedUsedInNestedFragment
-    ╭─[<unknown>:18:32]
+    ╭─[all_variable_uses_defined.graphql:18:32]
     │
  18 │   isHouseTrained(atOtherHomes: $atOtherHomes)
     │                                ──────┬──────  
@@ -20,10 +20,9 @@ Error: Variable $atOtherHomes not defined in operation variableIsNotDefinedUsedI
 ────╯
 
 Error: Variable $atOtherHomes not defined in operation houseTrainedQueryTwoNotDefined
-    ╭─[<unknown>:18:32]
+    ╭─[all_variable_uses_defined.graphql:18:32]
     │
  18 │   isHouseTrained(atOtherHomes: $atOtherHomes)
     │                                ──────┬──────  
     │                                      ╰──────── No variable definition with this name defined in operation houseTrainedQueryTwoNotDefined
 ────╯
-

--- a/bluejay-validator/tests/snapshots/executable_integration_test__error@all_variables_used.graphql.snap
+++ b/bluejay-validator/tests/snapshots/executable_integration_test__error@all_variables_used.graphql.snap
@@ -4,7 +4,7 @@ expression: formatted_errors
 input_file: bluejay-validator/tests/test_data/executable/error/all_variables_used.graphql
 ---
 Error: Variable definition $atOtherHomes not used
-   ╭─[<unknown>:1:22]
+   ╭─[all_variables_used.graphql:1:22]
    │
  1 │ query variableUnused($atOtherHomes: Boolean) {
    │                      ──────┬──────  
@@ -12,7 +12,7 @@ Error: Variable definition $atOtherHomes not used
 ───╯
 
 Error: Variable definition $atOtherHomes not used
-   ╭─[<unknown>:7:37]
+   ╭─[all_variables_used.graphql:7:37]
    │
  7 │ query variableNotUsedWithinFragment($atOtherHomes: Boolean) {
    │                                     ──────┬──────  
@@ -20,10 +20,9 @@ Error: Variable definition $atOtherHomes not used
 ───╯
 
 Error: Variable definition $extra not used
-    ╭─[<unknown>:23:49]
+    ╭─[all_variables_used.graphql:23:49]
     │
  23 │ query queryWithExtraVar($atOtherHomes: Boolean, $extra: Int) {
     │                                                 ───┬──  
     │                                                    ╰──── Variable definition not used
 ────╯
-

--- a/bluejay-validator/tests/snapshots/executable_integration_test__error@argument_names.graphql.snap
+++ b/bluejay-validator/tests/snapshots/executable_integration_test__error@argument_names.graphql.snap
@@ -4,7 +4,7 @@ expression: formatted_errors
 input_file: bluejay-validator/tests/test_data/executable/error/argument_names.graphql
 ---
 Error: Field `doesKnowCommand` does not define an argument named `command`
-   ╭─[<unknown>:3:21]
+   ╭─[argument_names.graphql:3:21]
    │
  3 │     doesKnowCommand(command: CLEAN_UP_HOUSE, dogCommand: SIT)
    │                     ───┬───  
@@ -12,10 +12,9 @@ Error: Field `doesKnowCommand` does not define an argument named `command`
 ───╯
 
 Error: Directive `include` does not define an argument named `unless`
-   ╭─[<unknown>:9:49]
+   ╭─[argument_names.graphql:9:49]
    │
  9 │     isHouseTrained(atOtherHomes: true) @include(unless: false, if: true)
    │                                                 ───┬──  
    │                                                    ╰──── No argument definition with this name
 ───╯
-

--- a/bluejay-validator/tests/snapshots/executable_integration_test__error@argument_uniqueness.graphql.snap
+++ b/bluejay-validator/tests/snapshots/executable_integration_test__error@argument_uniqueness.graphql.snap
@@ -4,7 +4,7 @@ expression: formatted_errors
 input_file: bluejay-validator/tests/test_data/executable/error/argument_uniqueness.graphql
 ---
 Error: Multiple arguments with name `dogCommand`
-   ╭─[<unknown>:1:1]
+   ╭─[argument_uniqueness.graphql:1:1]
    │
  3 │     doesKnowCommand(dogCommand: SIT, dogCommand: HEEL)
    │                     ─────┬────       ─────┬────  
@@ -14,7 +14,7 @@ Error: Multiple arguments with name `dogCommand`
 ───╯
 
 Error: Multiple arguments with name `atOtherHomes`
-   ╭─[<unknown>:1:1]
+   ╭─[argument_uniqueness.graphql:1:1]
    │
  9 │     isHouseTrained(atOtherHomes: true, atOtherHomes: false) @include(if: true, if: false)
    │                    ──────┬─────        ──────┬─────  
@@ -24,7 +24,7 @@ Error: Multiple arguments with name `atOtherHomes`
 ───╯
 
 Error: Multiple arguments with name `if`
-   ╭─[<unknown>:1:1]
+   ╭─[argument_uniqueness.graphql:1:1]
    │
  9 │     isHouseTrained(atOtherHomes: true, atOtherHomes: false) @include(if: true, if: false)
    │                                                                      ─┬        ─┬  
@@ -32,4 +32,3 @@ Error: Multiple arguments with name `if`
    │                                                                                 │  
    │                                                                                 ╰── Argument with name `if`
 ───╯
-

--- a/bluejay-validator/tests/snapshots/executable_integration_test__error@directives_are_defined.graphql.snap
+++ b/bluejay-validator/tests/snapshots/executable_integration_test__error@directives_are_defined.graphql.snap
@@ -4,10 +4,9 @@ expression: formatted_errors
 input_file: bluejay-validator/tests/test_data/executable/error/directives_are_defined.graphql
 ---
 Error: No directive definition with name `@doesNotExist`
-   ╭─[<unknown>:2:8]
+   ╭─[directives_are_defined.graphql:2:8]
    │
  2 │   dog @doesNotExist { name }
    │        ──────┬─────  
    │              ╰─────── No directive definition with this name
 ───╯
-

--- a/bluejay-validator/tests/snapshots/executable_integration_test__error@directives_are_in_valid_locations.graphql.snap
+++ b/bluejay-validator/tests/snapshots/executable_integration_test__error@directives_are_in_valid_locations.graphql.snap
@@ -4,10 +4,9 @@ expression: formatted_errors
 input_file: bluejay-validator/tests/test_data/executable/error/directives_are_in_valid_locations.graphql
 ---
 Error: Directive @skip cannot be used at location QUERY. It is only allowed at the following locations: FIELD, FRAGMENT_SPREAD, INLINE_FRAGMENT
-   ╭─[<unknown>:1:7]
+   ╭─[directives_are_in_valid_locations.graphql:1:7]
    │
  1 │ query @skip(if: true) {
    │       ───────┬───────  
    │              ╰───────── Cannot be used at location QUERY
 ───╯
-

--- a/bluejay-validator/tests/snapshots/executable_integration_test__error@directives_are_unique_per_location.graphql.snap
+++ b/bluejay-validator/tests/snapshots/executable_integration_test__error@directives_are_unique_per_location.graphql.snap
@@ -4,7 +4,7 @@ expression: formatted_errors
 input_file: bluejay-validator/tests/test_data/executable/error/directives_are_unique_per_location.graphql
 ---
 Error: Directive @skip is not repeatable but was used multiple times in the same location
-   ╭─[<unknown>:1:1]
+   ╭─[directives_are_unique_per_location.graphql:1:1]
    │
  2 │   dog @skip(if: $foo) @skip(if: $bar) { name }
    │       ───────┬─────── ───────┬───────  
@@ -12,4 +12,3 @@ Error: Directive @skip is not repeatable but was used multiple times in the same
    │                              │         
    │                              ╰───────── Usage of directive
 ───╯
-

--- a/bluejay-validator/tests/snapshots/executable_integration_test__error@field_selection_merging.graphql.snap
+++ b/bluejay-validator/tests/snapshots/executable_integration_test__error@field_selection_merging.graphql.snap
@@ -4,7 +4,7 @@ expression: formatted_errors
 input_file: bluejay-validator/tests/test_data/executable/error/field_selection_merging.graphql
 ---
 Error: Fields in selection set do not merge due to incompatible types
-   ╭─[<unknown>:2:7]
+   ╭─[field_selection_merging.graphql:2:7]
    │
  2 │ ╭─▶   dog {
  3 │ │       name: nickname
@@ -19,7 +19,7 @@ Error: Fields in selection set do not merge due to incompatible types
 ───╯
 
 Error: Fields in selection set do not merge due to unequal field names
-   ╭─[<unknown>:2:7]
+   ╭─[field_selection_merging.graphql:2:7]
    │
  2 │ ╭─▶   dog {
  3 │ │       name: nickname
@@ -34,7 +34,7 @@ Error: Fields in selection set do not merge due to unequal field names
 ───╯
 
 Error: Fields in selection set do not merge due to unequal arguments
-    ╭─[<unknown>:9:7]
+    ╭─[field_selection_merging.graphql:9:7]
     │
   9 │ ╭─▶   dog {
  10 │ │       doesKnowCommand(dogCommand: SIT)
@@ -49,7 +49,7 @@ Error: Fields in selection set do not merge due to unequal arguments
 ────╯
 
 Error: Fields in selection set do not merge due to unequal arguments
-    ╭─[<unknown>:16:7]
+    ╭─[field_selection_merging.graphql:16:7]
     │
  16 │ ╭─▶   dog {
  17 │ │       doesKnowCommand(dogCommand: SIT)
@@ -64,7 +64,7 @@ Error: Fields in selection set do not merge due to unequal arguments
 ────╯
 
 Error: Fields in selection set do not merge due to unequal arguments
-    ╭─[<unknown>:23:7]
+    ╭─[field_selection_merging.graphql:23:7]
     │
  23 │ ╭─▶   dog {
  24 │ │       doesKnowCommand(dogCommand: $varOne)
@@ -79,7 +79,7 @@ Error: Fields in selection set do not merge due to unequal arguments
 ────╯
 
 Error: Fields in selection set do not merge due to unequal arguments
-    ╭─[<unknown>:30:7]
+    ╭─[field_selection_merging.graphql:30:7]
     │
  30 │ ╭─▶   dog {
  31 │ │       doesKnowCommand(dogCommand: SIT)
@@ -94,7 +94,7 @@ Error: Fields in selection set do not merge due to unequal arguments
 ────╯
 
 Error: Fields in selection set do not merge due to incompatible types
-    ╭─[<unknown>:37:7]
+    ╭─[field_selection_merging.graphql:37:7]
     │
  37 │ ╭─▶   pet {
     ┆ ┆   
@@ -112,10 +112,9 @@ Error: Fields in selection set do not merge due to incompatible types
 ────╯
 
 Error: Field `doesKnowCommand` missing argument(s): dogCommand
-    ╭─[<unknown>:32:5]
+    ╭─[field_selection_merging.graphql:32:5]
     │
  32 │     doesKnowCommand
     │     ───────┬───────  
     │            ╰───────── Missing argument(s): dogCommand
 ────╯
-

--- a/bluejay-validator/tests/snapshots/executable_integration_test__error@field_selections.graphql.snap
+++ b/bluejay-validator/tests/snapshots/executable_integration_test__error@field_selections.graphql.snap
@@ -4,7 +4,7 @@ expression: formatted_errors
 input_file: bluejay-validator/tests/test_data/executable/error/field_selections.graphql
 ---
 Error: Field `name` does not exist on type `CatOrDog`
-   ╭─[<unknown>:3:5]
+   ╭─[field_selections.graphql:3:5]
    │
  3 │     name
    │     ──┬─  
@@ -12,10 +12,9 @@ Error: Field `name` does not exist on type `CatOrDog`
 ───╯
 
 Error: Field `barkVolume` does not exist on type `Pet`
-   ╭─[<unknown>:9:5]
+   ╭─[field_selections.graphql:9:5]
    │
  9 │     barkVolume
    │     ─────┬────  
    │          ╰────── Field does not exist on type `Pet`
 ───╯
-

--- a/bluejay-validator/tests/snapshots/executable_integration_test__error@fragment_name_uniqueness.graphql.snap
+++ b/bluejay-validator/tests/snapshots/executable_integration_test__error@fragment_name_uniqueness.graphql.snap
@@ -4,7 +4,7 @@ expression: formatted_errors
 input_file: bluejay-validator/tests/test_data/executable/error/fragment_name_uniqueness.graphql
 ---
 Error: Multiple fragment definitions named `fragmentOne`
-    ╭─[<unknown>:1:1]
+    ╭─[fragment_name_uniqueness.graphql:1:1]
     │
   7 │ fragment fragmentOne on Dog {
     │          ─────┬─────  
@@ -14,4 +14,3 @@ Error: Multiple fragment definitions named `fragmentOne`
     │          ─────┬─────  
     │               ╰─────── Fragment definition with name `fragmentOne`
 ────╯
-

--- a/bluejay-validator/tests/snapshots/executable_integration_test__error@fragment_spread_is_possible.graphql.snap
+++ b/bluejay-validator/tests/snapshots/executable_integration_test__error@fragment_spread_is_possible.graphql.snap
@@ -4,7 +4,7 @@ expression: formatted_errors
 input_file: bluejay-validator/tests/test_data/executable/error/fragment_spread_is_possible.graphql
 ---
 Error: Fragment targeting type Cat cannot be spread for type Dog
-   ╭─[<unknown>:2:3]
+   ╭─[fragment_spread_is_possible.graphql:2:3]
    │
  2 │ ╭─▶   ... on Cat {
    ┆ ┆   
@@ -14,7 +14,7 @@ Error: Fragment targeting type Cat cannot be spread for type Dog
 ───╯
 
 Error: Fragment targeting type Sentient cannot be spread for type Dog
-    ╭─[<unknown>:8:3]
+    ╭─[fragment_spread_is_possible.graphql:8:3]
     │
   8 │ ╭─▶   ... on Sentient {
     ┆ ┆   
@@ -24,7 +24,7 @@ Error: Fragment targeting type Sentient cannot be spread for type Dog
 ────╯
 
 Error: Fragment targeting type Dog cannot be spread for type Sentient
-    ╭─[<unknown>:14:3]
+    ╭─[fragment_spread_is_possible.graphql:14:3]
     │
  14 │ ╭─▶   ... on Dog {
     ┆ ┆   
@@ -34,7 +34,7 @@ Error: Fragment targeting type Dog cannot be spread for type Sentient
 ────╯
 
 Error: Fragment targeting type Cat cannot be spread for type HumanOrAlien
-    ╭─[<unknown>:20:3]
+    ╭─[fragment_spread_is_possible.graphql:20:3]
     │
  20 │ ╭─▶   ... on Cat {
     ┆ ┆   
@@ -44,10 +44,9 @@ Error: Fragment targeting type Cat cannot be spread for type HumanOrAlien
 ────╯
 
 Error: Fragment `sentientFragment` cannot be spread for type Pet
-    ╭─[<unknown>:26:6]
+    ╭─[fragment_spread_is_possible.graphql:26:6]
     │
  26 │   ...sentientFragment
     │      ────────┬───────  
     │              ╰───────── Cannot be spread for type Pet
 ────╯
-

--- a/bluejay-validator/tests/snapshots/executable_integration_test__error@fragment_spread_target_defined.graphql.snap
+++ b/bluejay-validator/tests/snapshots/executable_integration_test__error@fragment_spread_target_defined.graphql.snap
@@ -4,10 +4,9 @@ expression: formatted_errors
 input_file: bluejay-validator/tests/test_data/executable/error/fragment_spread_target_defined.graphql
 ---
 Error: No fragment defined with name `undefinedFragment`
-   ╭─[<unknown>:3:8]
+   ╭─[fragment_spread_target_defined.graphql:3:8]
    │
  3 │     ...undefinedFragment
    │        ────────┬────────  
    │                ╰────────── No fragment defined with this name
 ───╯
-

--- a/bluejay-validator/tests/snapshots/executable_integration_test__error@fragment_spread_type_exists.graphql.snap
+++ b/bluejay-validator/tests/snapshots/executable_integration_test__error@fragment_spread_type_exists.graphql.snap
@@ -4,7 +4,7 @@ expression: formatted_errors
 input_file: bluejay-validator/tests/test_data/executable/error/fragment_spread_type_exists.graphql
 ---
 Error: No type definition with name `NotInSchema`
-   ╭─[<unknown>:1:31]
+   ╭─[fragment_spread_type_exists.graphql:1:31]
    │
  1 │ fragment notOnExistingType on NotInSchema {
    │                               ─────┬─────  
@@ -12,10 +12,9 @@ Error: No type definition with name `NotInSchema`
 ───╯
 
 Error: No type definition with name `NotInSchema`
-   ╭─[<unknown>:6:10]
+   ╭─[fragment_spread_type_exists.graphql:6:10]
    │
  6 │   ... on NotInSchema {
    │          ─────┬─────  
    │               ╰─────── No type with this name
 ───╯
-

--- a/bluejay-validator/tests/snapshots/executable_integration_test__error@fragment_spreads_must_not_form_cycles.graphql.snap
+++ b/bluejay-validator/tests/snapshots/executable_integration_test__error@fragment_spreads_must_not_form_cycles.graphql.snap
@@ -4,7 +4,7 @@ expression: formatted_errors
 input_file: bluejay-validator/tests/test_data/executable/error/fragment_spreads_must_not_form_cycles.graphql
 ---
 Error: Cycle detected in fragment `barkVolumeFragment`
-    ╭─[<unknown>:9:6]
+    ╭─[fragment_spreads_must_not_form_cycles.graphql:9:6]
     │
   9 │   ...barkVolumeFragment
     │      ─────────┬────────  
@@ -16,7 +16,7 @@ Error: Cycle detected in fragment `barkVolumeFragment`
 ────╯
 
 Error: Cycle detected in fragment `nameFragment`
-    ╭─[<unknown>:14:6]
+    ╭─[fragment_spreads_must_not_form_cycles.graphql:14:6]
     │
   7 │ fragment nameFragment on Dog {
     │          ──────┬─────  
@@ -26,4 +26,3 @@ Error: Cycle detected in fragment `nameFragment`
     │      ──────┬─────  
     │            ╰─────── Cycle introduced by fragment spread
 ────╯
-

--- a/bluejay-validator/tests/snapshots/executable_integration_test__error@fragment_spreads_must_not_form_cycles_nested.graphql.snap
+++ b/bluejay-validator/tests/snapshots/executable_integration_test__error@fragment_spreads_must_not_form_cycles_nested.graphql.snap
@@ -4,7 +4,7 @@ expression: formatted_errors
 input_file: bluejay-validator/tests/test_data/executable/error/fragment_spreads_must_not_form_cycles_nested.graphql
 ---
 Error: Cycle detected in fragment `dogFragment`
-    ╭─[<unknown>:17:8]
+    ╭─[fragment_spreads_must_not_form_cycles_nested.graphql:17:8]
     │
   7 │ fragment dogFragment on Dog {
     │          ─────┬─────  
@@ -16,7 +16,7 @@ Error: Cycle detected in fragment `dogFragment`
 ────╯
 
 Error: Cycle detected in fragment `ownerFragment`
-    ╭─[<unknown>:10:8]
+    ╭─[fragment_spreads_must_not_form_cycles_nested.graphql:10:8]
     │
  10 │     ...ownerFragment
     │        ──────┬──────  
@@ -26,4 +26,3 @@ Error: Cycle detected in fragment `ownerFragment`
     │          ──────┬──────  
     │                ╰──────── Affected fragment definition
 ────╯
-

--- a/bluejay-validator/tests/snapshots/executable_integration_test__error@fragments_must_be_used.graphql.snap
+++ b/bluejay-validator/tests/snapshots/executable_integration_test__error@fragments_must_be_used.graphql.snap
@@ -4,10 +4,9 @@ expression: formatted_errors
 input_file: bluejay-validator/tests/test_data/executable/error/fragments_must_be_used.graphql
 ---
 Error: Fragment definition `nameFragment` is unused
-   ╭─[<unknown>:1:10]
+   ╭─[fragments_must_be_used.graphql:1:10]
    │
  1 │ fragment nameFragment on Dog { # unused
    │          ──────┬─────  
    │                ╰─────── Fragment definition is unused
 ───╯
-

--- a/bluejay-validator/tests/snapshots/executable_integration_test__error@fragments_on_composite_types.graphql.snap
+++ b/bluejay-validator/tests/snapshots/executable_integration_test__error@fragments_on_composite_types.graphql.snap
@@ -4,7 +4,7 @@ expression: formatted_errors
 input_file: bluejay-validator/tests/test_data/executable/error/fragments_on_composite_types.graphql
 ---
 Error: `Int` is not a composite type
-   ╭─[<unknown>:1:26]
+   ╭─[fragments_on_composite_types.graphql:1:26]
    │
  1 │ fragment fragOnScalar on Int {
    │                          ─┬─  
@@ -12,10 +12,9 @@ Error: `Int` is not a composite type
 ───╯
 
 Error: `Boolean` is not a composite type
-   ╭─[<unknown>:6:10]
+   ╭─[fragments_on_composite_types.graphql:6:10]
    │
  6 │   ... on Boolean {
    │          ───┬───  
    │             ╰───── Inline fragment target types must be composite types
 ───╯
-

--- a/bluejay-validator/tests/snapshots/executable_integration_test__error@leaf_field_selections.graphql.snap
+++ b/bluejay-validator/tests/snapshots/executable_integration_test__error@leaf_field_selections.graphql.snap
@@ -4,7 +4,7 @@ expression: formatted_errors
 input_file: bluejay-validator/tests/test_data/executable/error/leaf_field_selections.graphql
 ---
 Error: Selection on field of leaf type `Int` was not empty
-   ╭─[<unknown>:3:16]
+   ╭─[leaf_field_selections.graphql:3:16]
    │
  3 │ ╭─▶     barkVolume {
    ┆ ┆   
@@ -14,7 +14,7 @@ Error: Selection on field of leaf type `Int` was not empty
 ───╯
 
 Error: No selection on field of non-leaf type `Human`
-    ╭─[<unknown>:10:3]
+    ╭─[leaf_field_selections.graphql:10:3]
     │
  10 │   human
     │   ──┬──  
@@ -22,7 +22,7 @@ Error: No selection on field of non-leaf type `Human`
 ────╯
 
 Error: No selection on field of non-leaf type `Pet`
-    ╭─[<unknown>:14:3]
+    ╭─[leaf_field_selections.graphql:14:3]
     │
  14 │   pet
     │   ─┬─  
@@ -30,10 +30,9 @@ Error: No selection on field of non-leaf type `Pet`
 ────╯
 
 Error: No selection on field of non-leaf type `CatOrDog`
-    ╭─[<unknown>:18:3]
+    ╭─[leaf_field_selections.graphql:18:3]
     │
  18 │   catOrDog
     │   ────┬───  
     │       ╰───── Fields of non-leaf types must have a selection
 ────╯
-

--- a/bluejay-validator/tests/snapshots/executable_integration_test__error@lone_anonymous_operation.graphql.snap
+++ b/bluejay-validator/tests/snapshots/executable_integration_test__error@lone_anonymous_operation.graphql.snap
@@ -4,7 +4,7 @@ expression: formatted_errors
 input_file: bluejay-validator/tests/test_data/executable/error/lone_anonymous_operation.graphql
 ---
 Error: Anonymous operation not lone operation in document
-   ╭─[<unknown>:1:1]
+   ╭─[lone_anonymous_operation.graphql:1:1]
    │
  1 │ ╭─▶ {
    ┆ ┆   
@@ -12,4 +12,3 @@ Error: Anonymous operation not lone operation in document
    │ │       
    │ ╰─────── Anonymous operation definition
 ───╯
-

--- a/bluejay-validator/tests/snapshots/executable_integration_test__error@operation_name_uniqueness.graphql.snap
+++ b/bluejay-validator/tests/snapshots/executable_integration_test__error@operation_name_uniqueness.graphql.snap
@@ -4,7 +4,7 @@ expression: formatted_errors
 input_file: bluejay-validator/tests/test_data/executable/error/operation_name_uniqueness.graphql
 ---
 Error: Multiple operation definitions named `getName`
-   ╭─[<unknown>:1:1]
+   ╭─[operation_name_uniqueness.graphql:1:1]
    │
  1 │ query getName {
    │       ───┬───  
@@ -14,4 +14,3 @@ Error: Multiple operation definitions named `getName`
    │       ───┬───  
    │          ╰───── Operation definition with name `getName`
 ───╯
-

--- a/bluejay-validator/tests/snapshots/executable_integration_test__error@operation_type_is_defined.graphql.snap
+++ b/bluejay-validator/tests/snapshots/executable_integration_test__error@operation_type_is_defined.graphql.snap
@@ -4,10 +4,9 @@ expression: formatted_errors
 input_file: bluejay-validator/tests/test_data/executable/error/operation_type_is_defined.graphql
 ---
 Error: Schema does not define a mutation root
-   ╭─[<unknown>:1:1]
+   ╭─[operation_type_is_defined.graphql:1:1]
    │
  1 │ mutation {
    │ ────┬───  
    │     ╰───── Schema does not define a mutation root
 ───╯
-

--- a/bluejay-validator/tests/snapshots/executable_integration_test__error@required_arguments.graphql.snap
+++ b/bluejay-validator/tests/snapshots/executable_integration_test__error@required_arguments.graphql.snap
@@ -4,7 +4,7 @@ expression: formatted_errors
 input_file: bluejay-validator/tests/test_data/executable/error/required_arguments.graphql
 ---
 Error: Field `nonNullBooleanArgField` missing argument(s): nonNullBooleanArg
-   ╭─[<unknown>:3:5]
+   ╭─[required_arguments.graphql:3:5]
    │
  3 │     nonNullBooleanArgField
    │     ───────────┬──────────  
@@ -12,10 +12,9 @@ Error: Field `nonNullBooleanArgField` missing argument(s): nonNullBooleanArg
 ───╯
 
 Error: Got null when non-null value of type Boolean! was expected
-   ╭─[<unknown>:9:47]
+   ╭─[required_arguments.graphql:9:47]
    │
  9 │     nonNullBooleanArgField(nonNullBooleanArg: null)
    │                                               ──┬─  
    │                                                 ╰─── Expected non-null value
 ───╯
-

--- a/bluejay-validator/tests/snapshots/executable_integration_test__error@subscription_operation_definition_single_root_field.graphql.snap
+++ b/bluejay-validator/tests/snapshots/executable_integration_test__error@subscription_operation_definition_single_root_field.graphql.snap
@@ -4,7 +4,7 @@ expression: formatted_errors
 input_file: bluejay-validator/tests/test_data/executable/error/subscription_operation_definition_single_root_field.graphql
 ---
 Error: Subscription root is not a single field
-    ╭─[<unknown>:1:18]
+    ╭─[subscription_operation_definition_single_root_field.graphql:1:18]
     │
   1 │ ╭─▶ subscription sub {
     ┆ ┆   
@@ -12,4 +12,3 @@ Error: Subscription root is not a single field
     │ │       
     │ ╰─────── Selection set contains multiple fields
 ────╯
-

--- a/bluejay-validator/tests/snapshots/executable_integration_test__error@value_is_valid.graphql.snap
+++ b/bluejay-validator/tests/snapshots/executable_integration_test__error@value_is_valid.graphql.snap
@@ -4,7 +4,7 @@ expression: formatted_errors
 input_file: bluejay-validator/tests/test_data/executable/error/value_is_valid.graphql
 ---
 Error: No implicit conversion of integer to String
-   ╭─[<unknown>:6:28]
+   ╭─[value_is_valid.graphql:6:28]
    │
  6 │   findDog(complex: { name: 123 }) { name }
    │                            ─┬─  
@@ -12,7 +12,7 @@ Error: No implicit conversion of integer to String
 ───╯
 
 Error: No field with name favoriteCookieFlavor on input type ComplexInput
-    ╭─[<unknown>:13:22]
+    ╭─[value_is_valid.graphql:13:22]
     │
  13 │   findDog(complex: { favoriteCookieFlavor: "Bacon" }) { name }
     │                      ──────────┬─────────  
@@ -20,7 +20,7 @@ Error: No field with name favoriteCookieFlavor on input type ComplexInput
 ────╯
 
 Error: Object with multiple entries for field name
-    ╭─[<unknown>:1:1]
+    ╭─[value_is_valid.graphql:1:1]
     │
  17 │   findDog(complex: { name: "Fido", name: "Fido" }) { name }
     │                      ──┬─          ──┬─  
@@ -30,10 +30,9 @@ Error: Object with multiple entries for field name
 ────╯
 
 Error: No implicit conversion of string to Int
-   ╭─[<unknown>:2:23]
+   ╭─[value_is_valid.graphql:2:23]
    │
  2 │   intArgField(intArg: "123")
    │                       ──┬──  
    │                         ╰──── No implicit conversion to Int
 ───╯
-

--- a/bluejay-validator/tests/snapshots/executable_integration_test__error@variable_uniqueness.graphql.snap
+++ b/bluejay-validator/tests/snapshots/executable_integration_test__error@variable_uniqueness.graphql.snap
@@ -4,7 +4,7 @@ expression: formatted_errors
 input_file: bluejay-validator/tests/test_data/executable/error/variable_uniqueness.graphql
 ---
 Error: Multiple variable definitions named $atOtherHomes
-   ╭─[<unknown>:1:1]
+   ╭─[variable_uniqueness.graphql:1:1]
    │
  1 │ query houseTrainedQuery($atOtherHomes: Boolean, $atOtherHomes: Boolean) {
    │                         ──────┬──────           ──────┬──────  
@@ -12,4 +12,3 @@ Error: Multiple variable definitions named $atOtherHomes
    │                                                       │        
    │                                                       ╰──────── Variable definition with name $atOtherHomes
 ───╯
-

--- a/bluejay-validator/tests/snapshots/executable_integration_test__error@variables_are_input_types.graphql.snap
+++ b/bluejay-validator/tests/snapshots/executable_integration_test__error@variables_are_input_types.graphql.snap
@@ -4,7 +4,7 @@ expression: formatted_errors
 input_file: bluejay-validator/tests/test_data/executable/error/variables_are_input_types.graphql
 ---
 Error: Type of variable $cat, Cat, is not an input type
-   ╭─[<unknown>:1:22]
+   ╭─[variables_are_input_types.graphql:1:22]
    │
  1 │ query takesCat($cat: Cat) {
    │                      ─┬─  
@@ -12,7 +12,7 @@ Error: Type of variable $cat, Cat, is not an input type
 ───╯
 
 Error: Type of variable $dog, Dog, is not an input type
-   ╭─[<unknown>:5:26]
+   ╭─[variables_are_input_types.graphql:5:26]
    │
  5 │ query takesDogBang($dog: Dog!) {
    │                          ──┬─  
@@ -20,7 +20,7 @@ Error: Type of variable $dog, Dog, is not an input type
 ───╯
 
 Error: Type of variable $pets, Pet, is not an input type
-   ╭─[<unknown>:9:29]
+   ╭─[variables_are_input_types.graphql:9:29]
    │
  9 │ query takesListOfPet($pets: [Pet]) {
    │                             ──┬──  
@@ -28,7 +28,7 @@ Error: Type of variable $pets, Pet, is not an input type
 ───╯
 
 Error: Type of variable $catOrDog, CatOrDog, is not an input type
-    ╭─[<unknown>:13:32]
+    ╭─[variables_are_input_types.graphql:13:32]
     │
  13 │ query takesCatOrDog($catOrDog: CatOrDog) {
     │                                ────┬───  
@@ -36,10 +36,9 @@ Error: Type of variable $catOrDog, CatOrDog, is not an input type
 ────╯
 
 Error: Type of variable $nonExistent, NonExistent, is not an input type
-    ╭─[<unknown>:17:38]
+    ╭─[variables_are_input_types.graphql:17:38]
     │
  17 │ query takesNonExistent($nonExistent: NonExistent) {
     │                                      ─────┬─────  
     │                                           ╰─────── Not an input type
 ────╯
-

--- a/bluejay-visibility/tests/integration_test.rs
+++ b/bluejay-visibility/tests/integration_test.rs
@@ -140,7 +140,7 @@ fn test_visibility() {
                 panic!(
                     "Schema `{}` had parse errors:\n{}",
                     path.display(),
-                    Error::format_errors(&input, errors)
+                    Error::format_errors(&input, path.file_name().and_then(|f| f.to_str()), errors)
                 )
             });
         let schema_definition = ParserSchemaDefinition::try_from(&definition_document)
@@ -148,7 +148,7 @@ fn test_visibility() {
                 panic!(
                     "Schema `{}` had coercion errors:\n:{}",
                     path.display(),
-                    Error::format_errors(&input, errors)
+                    Error::format_errors(&input, path.file_name().and_then(|f| f.to_str()), errors)
                 )
             });
 
@@ -178,14 +178,14 @@ fn test_fields_definition_get() {
         DefinitionDocument::parse(schema).unwrap_or_else(|errors| {
             panic!(
                 "Schema had parse errors:\n{}",
-                Error::format_errors(schema, errors)
+                Error::format_errors(schema, None, errors)
             )
         });
     let schema_definition =
         ParserSchemaDefinition::try_from(&definition_document).unwrap_or_else(|errors| {
             panic!(
                 "Schema had coercion errors:\n:{}",
-                Error::format_errors(schema, errors)
+                Error::format_errors(schema, None, errors)
             )
         });
 


### PR DESCRIPTION
Accept a filename in the `format_errors` method and use that when printing references to the source document