### PR TITLE
Fix cargo doc failure for typegen-macro crate

### DIFF
--- a/bluejay-typegen-macro/Cargo.toml
+++ b/bluejay-typegen-macro/Cargo.toml
@@ -25,6 +25,7 @@ itertools = "0.13.0"
 proc-macro = true
 
 [features]
+default = ["serde"]
 serde = []
 miniserde = []
 

--- a/bluejay-typegen/Cargo.toml
+++ b/bluejay-typegen/Cargo.toml
@@ -10,7 +10,7 @@ exclude = [".gitignore", "tests/**/*"]
 description = "A GraphQL type generator"
 
 [dependencies]
-bluejay-typegen-macro = { workspace = true }
+bluejay-typegen-macro = { workspace = true, default-features = false }
 # rename these packages to prevent the tests from passing if the macro generates code
 # referencing them directly instead of the re-exports
 srd = { package = "serde", version = "1.0", features = ["derive"], optional = true }


### PR DESCRIPTION
It was failing because neither `serde` nor `miniserde` features were enabled so I set a default