### PR TITLE
Add depth limiter to parser

### DIFF
--- a/bluejay-parser/src/ast.rs
+++ b/bluejay-parser/src/ast.rs
@@ -1,6 +1,7 @@
 mod argument;
 mod arguments;
 pub mod definition;
+mod depth_limiter;
 mod directive;
 mod directives;
 pub mod executable;
@@ -15,6 +16,7 @@ mod value;
 
 pub use argument::{Argument, ConstArgument, VariableArgument};
 pub use arguments::{Arguments, VariableArguments};
+pub use depth_limiter::DepthLimiter;
 pub use directive::{ConstDirective, Directive, VariableDirective};
 pub use directives::{ConstDirectives, Directives, VariableDirectives};
 use from_tokens::FromTokens;

--- a/bluejay-parser/src/ast/argument.rs
+++ b/bluejay-parser/src/ast/argument.rs
@@ -1,4 +1,4 @@
-use crate::ast::{FromTokens, ParseError, Tokens, Value};
+use crate::ast::{DepthLimiter, FromTokens, ParseError, Tokens, Value};
 use crate::lexical_token::{Name, PunctuatorType};
 use crate::{HasSpan, Span};
 
@@ -24,10 +24,13 @@ pub type VariableArgument<'a> = Argument<'a, false>;
 
 impl<'a, const CONST: bool> FromTokens<'a> for Argument<'a, CONST> {
     #[inline]
-    fn from_tokens(tokens: &mut impl Tokens<'a>) -> Result<Self, ParseError> {
+    fn from_tokens(
+        tokens: &mut impl Tokens<'a>,
+        depth_limiter: DepthLimiter,
+    ) -> Result<Self, ParseError> {
         let name = tokens.expect_name()?;
         tokens.expect_punctuator(PunctuatorType::Colon)?;
-        let value = Value::from_tokens(tokens)?;
+        let value = Value::from_tokens(tokens, depth_limiter.bump()?)?;
         let span = name.span().merge(value.span());
         Ok(Self { name, value, span })
     }

--- a/bluejay-parser/src/ast/arguments.rs
+++ b/bluejay-parser/src/ast/arguments.rs
@@ -1,4 +1,4 @@
-use crate::ast::{Argument, FromTokens, IsMatch, ParseError, Tokens};
+use crate::ast::{Argument, DepthLimiter, FromTokens, IsMatch, ParseError, Tokens};
 use crate::lexical_token::PunctuatorType;
 use crate::{HasSpan, Span};
 use bluejay_core::AsIter;
@@ -13,11 +13,14 @@ pub type VariableArguments<'a> = Arguments<'a, false>;
 
 impl<'a, const CONST: bool> FromTokens<'a> for Arguments<'a, CONST> {
     #[inline]
-    fn from_tokens(tokens: &mut impl Tokens<'a>) -> Result<Self, ParseError> {
+    fn from_tokens(
+        tokens: &mut impl Tokens<'a>,
+        depth_limiter: DepthLimiter,
+    ) -> Result<Self, ParseError> {
         let open_span = tokens.expect_punctuator(PunctuatorType::OpenRoundBracket)?;
         let mut arguments: Vec<Argument<CONST>> = Vec::new();
         let close_span = loop {
-            arguments.push(Argument::from_tokens(tokens)?);
+            arguments.push(Argument::from_tokens(tokens, depth_limiter.bump()?)?);
             if let Some(close_span) = tokens.next_if_punctuator(PunctuatorType::CloseRoundBracket) {
                 break close_span;
             }

--- a/bluejay-parser/src/ast/definition/custom_scalar_type_definition.rs
+++ b/bluejay-parser/src/ast/definition/custom_scalar_type_definition.rs
@@ -1,6 +1,6 @@
 use crate::ast::{
     definition::{Context, Directives},
-    ConstDirectives, FromTokens, ParseError, Tokens, TryFromTokens,
+    ConstDirectives, DepthLimiter, FromTokens, ParseError, Tokens, TryFromTokens,
 };
 use crate::lexical_token::{Name, StringValue};
 use crate::Span;
@@ -46,11 +46,15 @@ impl<'a, C: Context> CustomScalarTypeDefinition<'a, C> {
 }
 
 impl<'a, C: Context> FromTokens<'a> for CustomScalarTypeDefinition<'a, C> {
-    fn from_tokens(tokens: &mut impl Tokens<'a>) -> Result<Self, ParseError> {
+    fn from_tokens(
+        tokens: &mut impl Tokens<'a>,
+        depth_limiter: DepthLimiter,
+    ) -> Result<Self, ParseError> {
         let description = tokens.next_if_string_value();
         let scalar_identifier_span = tokens.expect_name_value(Self::SCALAR_IDENTIFIER)?;
         let name = tokens.expect_name()?;
-        let directives = ConstDirectives::try_from_tokens(tokens).transpose()?;
+        let directives =
+            ConstDirectives::try_from_tokens(tokens, depth_limiter.bump()?).transpose()?;
         Ok(Self {
             description,
             _scalar_identifier_span: scalar_identifier_span,

--- a/bluejay-parser/src/ast/definition/enum_value_definition.rs
+++ b/bluejay-parser/src/ast/definition/enum_value_definition.rs
@@ -1,3 +1,4 @@
+use crate::ast::DepthLimiter;
 use crate::lexical_token::{Name, StringValue};
 use crate::{
     ast::{
@@ -32,7 +33,10 @@ impl<'a, C: Context> CoreEnumValueDefinition for EnumValueDefinition<'a, C> {
 }
 
 impl<'a, C: Context> FromTokens<'a> for EnumValueDefinition<'a, C> {
-    fn from_tokens(tokens: &mut impl Tokens<'a>) -> Result<Self, ParseError> {
+    fn from_tokens(
+        tokens: &mut impl Tokens<'a>,
+        depth_limiter: DepthLimiter,
+    ) -> Result<Self, ParseError> {
         let description = tokens.next_if_string_value();
         let name = tokens.expect_name()?;
         if matches!(name.as_str(), "null" | "true" | "false") {
@@ -42,7 +46,8 @@ impl<'a, C: Context> FromTokens<'a> for EnumValueDefinition<'a, C> {
             });
         }
 
-        let directives = ConstDirectives::try_from_tokens(tokens).transpose()?;
+        let directives =
+            ConstDirectives::try_from_tokens(tokens, depth_limiter.bump()?).transpose()?;
         Ok(Self {
             description,
             name,

--- a/bluejay-parser/src/ast/definition/enum_value_definitions.rs
+++ b/bluejay-parser/src/ast/definition/enum_value_definitions.rs
@@ -1,5 +1,5 @@
 use crate::ast::definition::{Context, EnumValueDefinition};
-use crate::ast::{FromTokens, ParseError, Tokens};
+use crate::ast::{DepthLimiter, FromTokens, ParseError, Tokens};
 use crate::lexical_token::PunctuatorType;
 use crate::Span;
 use bluejay_core::definition::EnumValueDefinitions as CoreEnumValueDefinitions;
@@ -25,11 +25,17 @@ impl<'a, C: Context> CoreEnumValueDefinitions for EnumValueDefinitions<'a, C> {
 }
 
 impl<'a, C: Context> FromTokens<'a> for EnumValueDefinitions<'a, C> {
-    fn from_tokens(tokens: &mut impl Tokens<'a>) -> Result<Self, ParseError> {
+    fn from_tokens(
+        tokens: &mut impl Tokens<'a>,
+        depth_limiter: DepthLimiter,
+    ) -> Result<Self, ParseError> {
         let open_span = tokens.expect_punctuator(PunctuatorType::OpenBrace)?;
         let mut enum_value_definitions = Vec::new();
         let close_span = loop {
-            enum_value_definitions.push(EnumValueDefinition::from_tokens(tokens)?);
+            enum_value_definitions.push(EnumValueDefinition::from_tokens(
+                tokens,
+                depth_limiter.bump()?,
+            )?);
             if let Some(close_span) = tokens.next_if_punctuator(PunctuatorType::CloseBrace) {
                 break close_span;
             }

--- a/bluejay-parser/src/ast/definition/interface_implementation.rs
+++ b/bluejay-parser/src/ast/definition/interface_implementation.rs
@@ -1,7 +1,7 @@
 use std::marker::PhantomData;
 
 use crate::ast::definition::{Context, InterfaceTypeDefinition};
-use crate::ast::{FromTokens, ParseError, Tokens};
+use crate::ast::{DepthLimiter, FromTokens, ParseError, Tokens};
 use crate::lexical_token::Name;
 use bluejay_core::definition::{
     InterfaceImplementation as CoreInterfaceImplementation,
@@ -43,7 +43,7 @@ impl<'a, C: Context> InterfaceImplementation<'a, C> {
 }
 
 impl<'a, C: Context> FromTokens<'a> for InterfaceImplementation<'a, C> {
-    fn from_tokens(tokens: &mut impl Tokens<'a>) -> Result<Self, ParseError> {
+    fn from_tokens(tokens: &mut impl Tokens<'a>, _: DepthLimiter) -> Result<Self, ParseError> {
         tokens.expect_name().map(|name| Self {
             name,
             context: PhantomData,

--- a/bluejay-parser/src/ast/definition/interface_type_definition.rs
+++ b/bluejay-parser/src/ast/definition/interface_type_definition.rs
@@ -1,5 +1,5 @@
 use crate::ast::definition::{Context, Directives, FieldsDefinition, InterfaceImplementations};
-use crate::ast::{ConstDirectives, FromTokens, ParseError, Tokens, TryFromTokens};
+use crate::ast::{ConstDirectives, DepthLimiter, FromTokens, ParseError, Tokens, TryFromTokens};
 use crate::lexical_token::{Name, StringValue};
 use bluejay_core::definition::{
     HasDirectives, InterfaceTypeDefinition as CoreInterfaceTypeDefinition,
@@ -44,14 +44,18 @@ impl<'a, C: Context> InterfaceTypeDefinition<'a, C> {
 }
 
 impl<'a, C: Context> FromTokens<'a> for InterfaceTypeDefinition<'a, C> {
-    fn from_tokens(tokens: &mut impl Tokens<'a>) -> Result<Self, ParseError> {
+    fn from_tokens(
+        tokens: &mut impl Tokens<'a>,
+        depth_limiter: DepthLimiter,
+    ) -> Result<Self, ParseError> {
         let description = tokens.next_if_string_value();
         tokens.expect_name_value(Self::INTERFACE_IDENTIFIER)?;
         let name = tokens.expect_name()?;
         let interface_implementations =
-            InterfaceImplementations::try_from_tokens(tokens).transpose()?;
-        let directives = ConstDirectives::try_from_tokens(tokens).transpose()?;
-        let fields_definition = FieldsDefinition::from_tokens(tokens)?;
+            InterfaceImplementations::try_from_tokens(tokens, depth_limiter.bump()?).transpose()?;
+        let directives =
+            ConstDirectives::try_from_tokens(tokens, depth_limiter.bump()?).transpose()?;
+        let fields_definition = FieldsDefinition::from_tokens(tokens, depth_limiter.bump()?)?;
         Ok(Self {
             description,
             name,

--- a/bluejay-parser/src/ast/definition/output_type.rs
+++ b/bluejay-parser/src/ast/definition/output_type.rs
@@ -2,7 +2,7 @@ use crate::ast::definition::{
     Context, CustomScalarTypeDefinition, EnumTypeDefinition, InterfaceTypeDefinition,
     ObjectTypeDefinition, TypeDefinition, UnionTypeDefinition,
 };
-use crate::ast::{FromTokens, ParseError, Tokens};
+use crate::ast::{DepthLimiter, FromTokens, ParseError, Tokens};
 use crate::lexical_token::{Name, PunctuatorType};
 use crate::{HasSpan, Span};
 use bluejay_core::definition::{
@@ -107,9 +107,12 @@ impl<'a, C: Context + 'a> CoreOutputType for OutputType<'a, C> {
 }
 
 impl<'a, C: Context + 'a> FromTokens<'a> for OutputType<'a, C> {
-    fn from_tokens(tokens: &mut impl Tokens<'a>) -> Result<Self, ParseError> {
+    fn from_tokens(
+        tokens: &mut impl Tokens<'a>,
+        depth_limiter: DepthLimiter,
+    ) -> Result<Self, ParseError> {
         if let Some(open_span) = tokens.next_if_punctuator(PunctuatorType::OpenSquareBracket) {
-            let inner = Self::from_tokens(tokens).map(Box::new)?;
+            let inner = Self::from_tokens(tokens, depth_limiter.bump()?).map(Box::new)?;
             let close_span = tokens.expect_punctuator(PunctuatorType::CloseSquareBracket)?;
             let bang_span = tokens.next_if_punctuator(PunctuatorType::Bang);
             let span = open_span.merge(&close_span);

--- a/bluejay-parser/src/ast/definition/union_member_type.rs
+++ b/bluejay-parser/src/ast/definition/union_member_type.rs
@@ -1,7 +1,7 @@
 use std::marker::PhantomData;
 
 use crate::ast::definition::{Context, ObjectTypeDefinition};
-use crate::ast::{FromTokens, ParseError, Tokens};
+use crate::ast::{DepthLimiter, FromTokens, ParseError, Tokens};
 use crate::lexical_token::Name;
 use bluejay_core::definition::{SchemaDefinition, UnionMemberType as CoreUnionMemberType};
 
@@ -37,7 +37,7 @@ impl<'a, C: Context> UnionMemberType<'a, C> {
 }
 
 impl<'a, C: Context> FromTokens<'a> for UnionMemberType<'a, C> {
-    fn from_tokens(tokens: &mut impl Tokens<'a>) -> Result<Self, ParseError> {
+    fn from_tokens(tokens: &mut impl Tokens<'a>, _: DepthLimiter) -> Result<Self, ParseError> {
         tokens.expect_name().map(|name| Self {
             name,
             context: PhantomData,

--- a/bluejay-parser/src/ast/definition/union_member_types.rs
+++ b/bluejay-parser/src/ast/definition/union_member_types.rs
@@ -1,5 +1,5 @@
 use crate::ast::definition::{Context, UnionMemberType};
-use crate::ast::{FromTokens, ParseError, Tokens};
+use crate::ast::{DepthLimiter, FromTokens, ParseError, Tokens};
 use crate::lexical_token::PunctuatorType;
 use bluejay_core::definition::UnionMemberTypes as CoreUnionMemberTypes;
 use bluejay_core::AsIter;
@@ -23,11 +23,15 @@ impl<'a, C: Context> CoreUnionMemberTypes for UnionMemberTypes<'a, C> {
 }
 
 impl<'a, C: Context> FromTokens<'a> for UnionMemberTypes<'a, C> {
-    fn from_tokens(tokens: &mut impl Tokens<'a>) -> Result<Self, ParseError> {
+    fn from_tokens(
+        tokens: &mut impl Tokens<'a>,
+        depth_limiter: DepthLimiter,
+    ) -> Result<Self, ParseError> {
         tokens.next_if_punctuator(PunctuatorType::Pipe);
-        let mut union_member_types = vec![UnionMemberType::from_tokens(tokens)?];
+        let mut union_member_types =
+            vec![UnionMemberType::from_tokens(tokens, depth_limiter.bump()?)?];
         while tokens.next_if_punctuator(PunctuatorType::Pipe).is_some() {
-            union_member_types.push(UnionMemberType::from_tokens(tokens)?);
+            union_member_types.push(UnionMemberType::from_tokens(tokens, depth_limiter.bump()?)?);
         }
         Ok(Self { union_member_types })
     }

--- a/bluejay-parser/src/ast/definition/union_type_definition.rs
+++ b/bluejay-parser/src/ast/definition/union_type_definition.rs
@@ -1,5 +1,5 @@
 use crate::ast::definition::{Context, Directives, FieldsDefinition, UnionMemberTypes};
-use crate::ast::{ConstDirectives, FromTokens, ParseError, Tokens, TryFromTokens};
+use crate::ast::{ConstDirectives, DepthLimiter, FromTokens, ParseError, Tokens, TryFromTokens};
 use crate::lexical_token::{Name, PunctuatorType, StringValue};
 use bluejay_core::definition::{HasDirectives, UnionTypeDefinition as CoreUnionTypeDefinition};
 
@@ -42,13 +42,17 @@ impl<'a, C: Context> UnionTypeDefinition<'a, C> {
 }
 
 impl<'a, C: Context> FromTokens<'a> for UnionTypeDefinition<'a, C> {
-    fn from_tokens(tokens: &mut impl Tokens<'a>) -> Result<Self, ParseError> {
+    fn from_tokens(
+        tokens: &mut impl Tokens<'a>,
+        depth_limiter: DepthLimiter,
+    ) -> Result<Self, ParseError> {
         let description = tokens.next_if_string_value();
         tokens.expect_name_value(Self::UNION_IDENTIFIER)?;
         let name = tokens.expect_name()?;
-        let directives = ConstDirectives::try_from_tokens(tokens).transpose()?;
+        let directives =
+            ConstDirectives::try_from_tokens(tokens, depth_limiter.bump()?).transpose()?;
         tokens.expect_punctuator(PunctuatorType::Equals)?;
-        let member_types = UnionMemberTypes::from_tokens(tokens)?;
+        let member_types = UnionMemberTypes::from_tokens(tokens, depth_limiter.bump()?)?;
         Ok(Self {
             description,
             name,

--- a/bluejay-parser/src/ast/depth_limiter.rs
+++ b/bluejay-parser/src/ast/depth_limiter.rs
@@ -1,0 +1,39 @@
+use crate::ast::ParseError;
+
+pub const DEFAULT_MAX_DEPTH: usize = 2000;
+
+/// A depth limiter is used to limit the depth of the AST. This is useful to prevent stack overflows.
+/// This intentionally does not implement `Clone` or `Copy` to passing this down the call stack without bumping.
+pub struct DepthLimiter {
+    max_depth: usize,
+    current_depth: usize,
+}
+
+impl Default for DepthLimiter {
+    fn default() -> Self {
+        Self {
+            max_depth: DEFAULT_MAX_DEPTH,
+            current_depth: 0,
+        }
+    }
+}
+
+impl DepthLimiter {
+    pub fn new(max_depth: usize) -> Self {
+        Self {
+            max_depth,
+            current_depth: 0,
+        }
+    }
+
+    pub fn bump(&self) -> Result<Self, ParseError> {
+        if self.current_depth >= self.max_depth {
+            Err(ParseError::MaxDepthExceeded)
+        } else {
+            Ok(Self {
+                max_depth: self.max_depth,
+                current_depth: self.current_depth + 1,
+            })
+        }
+    }
+}

--- a/bluejay-parser/src/ast/directive.rs
+++ b/bluejay-parser/src/ast/directive.rs
@@ -1,4 +1,4 @@
-use crate::ast::{Arguments, FromTokens, IsMatch, ParseError, Tokens, TryFromTokens};
+use crate::ast::{Arguments, DepthLimiter, FromTokens, IsMatch, ParseError, Tokens, TryFromTokens};
 use crate::lexical_token::{Name, PunctuatorType};
 use crate::{HasSpan, Span};
 
@@ -21,10 +21,13 @@ impl<'a, const CONST: bool> IsMatch<'a> for Directive<'a, CONST> {
 
 impl<'a, const CONST: bool> FromTokens<'a> for Directive<'a, CONST> {
     #[inline]
-    fn from_tokens(tokens: &mut impl Tokens<'a>) -> Result<Self, ParseError> {
+    fn from_tokens(
+        tokens: &mut impl Tokens<'a>,
+        depth_limiter: DepthLimiter,
+    ) -> Result<Self, ParseError> {
         let at_span = tokens.expect_punctuator(PunctuatorType::At)?;
         let name = tokens.expect_name()?;
-        let arguments = Arguments::try_from_tokens(tokens).transpose()?;
+        let arguments = Arguments::try_from_tokens(tokens, depth_limiter.bump()?).transpose()?;
         let span = match &arguments {
             Some(arguments) => at_span.merge(arguments.span()),
             None => at_span.merge(name.span()),

--- a/bluejay-parser/src/ast/directives.rs
+++ b/bluejay-parser/src/ast/directives.rs
@@ -1,5 +1,5 @@
 use crate::{
-    ast::{Directive, FromTokens, IsMatch, ParseError, Tokens, TryFromTokens},
+    ast::{DepthLimiter, Directive, FromTokens, IsMatch, ParseError, Tokens, TryFromTokens},
     HasSpan, Span,
 };
 use bluejay_core::AsIter;
@@ -15,9 +15,12 @@ pub type VariableDirectives<'a> = Directives<'a, false>;
 
 impl<'a, const CONST: bool> FromTokens<'a> for Directives<'a, CONST> {
     #[inline]
-    fn from_tokens(tokens: &mut impl Tokens<'a>) -> Result<Self, ParseError> {
+    fn from_tokens(
+        tokens: &mut impl Tokens<'a>,
+        depth_limiter: DepthLimiter,
+    ) -> Result<Self, ParseError> {
         let mut directives: Vec<Directive<'a, CONST>> = Vec::new();
-        while let Some(directive) = Directive::try_from_tokens(tokens) {
+        while let Some(directive) = Directive::try_from_tokens(tokens, depth_limiter.bump()?) {
             directives.push(directive?);
         }
         let span = match directives.as_slice() {

--- a/bluejay-parser/src/ast/executable/executable_definition.rs
+++ b/bluejay-parser/src/ast/executable/executable_definition.rs
@@ -1,5 +1,5 @@
 use crate::ast::executable::{FragmentDefinition, OperationDefinition};
-use crate::ast::{FromTokens, IsMatch, ParseError, Tokens};
+use crate::ast::{DepthLimiter, FromTokens, IsMatch, ParseError, Tokens};
 
 #[derive(Debug)]
 pub enum ExecutableDefinition<'a> {
@@ -9,11 +9,15 @@ pub enum ExecutableDefinition<'a> {
 
 impl<'a> FromTokens<'a> for ExecutableDefinition<'a> {
     #[inline]
-    fn from_tokens(tokens: &mut impl Tokens<'a>) -> Result<Self, ParseError> {
+    fn from_tokens(
+        tokens: &mut impl Tokens<'a>,
+        depth_limiter: DepthLimiter,
+    ) -> Result<Self, ParseError> {
+        // don't bump depth limiters because this is just a thin wrapper in the AST
         if OperationDefinition::is_match(tokens) {
-            OperationDefinition::from_tokens(tokens).map(Self::Operation)
+            OperationDefinition::from_tokens(tokens, depth_limiter).map(Self::Operation)
         } else if FragmentDefinition::is_match(tokens) {
-            FragmentDefinition::from_tokens(tokens).map(Self::Fragment)
+            FragmentDefinition::from_tokens(tokens, depth_limiter).map(Self::Fragment)
         } else {
             Err(tokens.unexpected_token())
         }

--- a/bluejay-parser/src/ast/executable/fragment_spread.rs
+++ b/bluejay-parser/src/ast/executable/fragment_spread.rs
@@ -1,6 +1,6 @@
 use crate::ast::executable::TypeCondition;
 use crate::ast::try_from_tokens::TryFromTokens;
-use crate::ast::{FromTokens, IsMatch, ParseError, Tokens, VariableDirectives};
+use crate::ast::{DepthLimiter, FromTokens, IsMatch, ParseError, Tokens, VariableDirectives};
 use crate::lexical_token::{Name, PunctuatorType};
 use crate::{HasSpan, Span};
 
@@ -13,11 +13,15 @@ pub struct FragmentSpread<'a> {
 
 impl<'a> FromTokens<'a> for FragmentSpread<'a> {
     #[inline]
-    fn from_tokens(tokens: &mut impl Tokens<'a>) -> Result<Self, ParseError> {
+    fn from_tokens(
+        tokens: &mut impl Tokens<'a>,
+        depth_limiter: DepthLimiter,
+    ) -> Result<Self, ParseError> {
         let ellipse_span = tokens.expect_punctuator(PunctuatorType::Ellipse)?;
         let name = tokens.expect_name()?;
         assert_ne!(TypeCondition::ON, name.as_ref());
-        let directives = VariableDirectives::try_from_tokens(tokens).transpose()?;
+        let directives =
+            VariableDirectives::try_from_tokens(tokens, depth_limiter.bump()?).transpose()?;
         let span = ellipse_span.merge(name.span());
         Ok(Self {
             name,

--- a/bluejay-parser/src/ast/executable/selection_set.rs
+++ b/bluejay-parser/src/ast/executable/selection_set.rs
@@ -1,5 +1,5 @@
 use crate::ast::executable::Selection;
-use crate::ast::{FromTokens, IsMatch, ParseError, Tokens};
+use crate::ast::{DepthLimiter, FromTokens, IsMatch, ParseError, Tokens};
 use crate::lexical_token::PunctuatorType;
 use crate::{HasSpan, Span};
 use bluejay_core::AsIter;
@@ -12,11 +12,14 @@ pub struct SelectionSet<'a> {
 
 impl<'a> FromTokens<'a> for SelectionSet<'a> {
     #[inline]
-    fn from_tokens(tokens: &mut impl Tokens<'a>) -> Result<Self, ParseError> {
+    fn from_tokens(
+        tokens: &mut impl Tokens<'a>,
+        depth_limiter: DepthLimiter,
+    ) -> Result<Self, ParseError> {
         let open_span = tokens.expect_punctuator(PunctuatorType::OpenBrace)?;
         let mut selections: Vec<Selection> = Vec::new();
         let close_span = loop {
-            selections.push(Selection::from_tokens(tokens)?);
+            selections.push(Selection::from_tokens(tokens, depth_limiter.bump()?)?);
             if let Some(close_span) = tokens.next_if_punctuator(PunctuatorType::CloseBrace) {
                 break close_span;
             }

--- a/bluejay-parser/src/ast/executable/type_condition.rs
+++ b/bluejay-parser/src/ast/executable/type_condition.rs
@@ -1,4 +1,4 @@
-use crate::ast::{FromTokens, IsMatch, ParseError, Tokens};
+use crate::ast::{DepthLimiter, FromTokens, IsMatch, ParseError, Tokens};
 use crate::lexical_token::Name;
 
 #[derive(Debug)]
@@ -8,7 +8,7 @@ pub struct TypeCondition<'a> {
 
 impl<'a> FromTokens<'a> for TypeCondition<'a> {
     #[inline]
-    fn from_tokens(tokens: &mut impl Tokens<'a>) -> Result<Self, ParseError> {
+    fn from_tokens(tokens: &mut impl Tokens<'a>, _: DepthLimiter) -> Result<Self, ParseError> {
         tokens.expect_name_value(Self::ON)?;
         let named_type = tokens.expect_name()?;
         Ok(Self { named_type })

--- a/bluejay-parser/src/ast/executable/variable_definitions.rs
+++ b/bluejay-parser/src/ast/executable/variable_definitions.rs
@@ -1,5 +1,5 @@
 use crate::ast::executable::VariableDefinition;
-use crate::ast::{FromTokens, IsMatch, ParseError, Tokens};
+use crate::ast::{DepthLimiter, FromTokens, IsMatch, ParseError, Tokens};
 use crate::lexical_token::PunctuatorType;
 use crate::Span;
 use bluejay_core::AsIter;
@@ -12,11 +12,17 @@ pub struct VariableDefinitions<'a> {
 
 impl<'a> FromTokens<'a> for VariableDefinitions<'a> {
     #[inline]
-    fn from_tokens(tokens: &mut impl Tokens<'a>) -> Result<Self, ParseError> {
+    fn from_tokens(
+        tokens: &mut impl Tokens<'a>,
+        depth_limiter: DepthLimiter,
+    ) -> Result<Self, ParseError> {
         let open_span = tokens.expect_punctuator(PunctuatorType::OpenRoundBracket)?;
         let mut variable_definitions: Vec<VariableDefinition> = Vec::new();
         let close_span = loop {
-            variable_definitions.push(VariableDefinition::from_tokens(tokens)?);
+            variable_definitions.push(VariableDefinition::from_tokens(
+                tokens,
+                depth_limiter.bump()?,
+            )?);
             if let Some(close_span) = tokens.next_if_punctuator(PunctuatorType::CloseRoundBracket) {
                 break close_span;
             }

--- a/bluejay-parser/src/ast/executable/variable_type.rs
+++ b/bluejay-parser/src/ast/executable/variable_type.rs
@@ -1,4 +1,4 @@
-use crate::ast::{FromTokens, ParseError, Tokens};
+use crate::ast::{DepthLimiter, FromTokens, ParseError, Tokens};
 use crate::lexical_token::{Name, PunctuatorType};
 use crate::{HasSpan, Span};
 use bluejay_core::{
@@ -43,9 +43,12 @@ impl<'a> CoreVariableType for VariableType<'a> {
 
 impl<'a> FromTokens<'a> for VariableType<'a> {
     #[inline]
-    fn from_tokens(tokens: &mut impl Tokens<'a>) -> Result<Self, ParseError> {
+    fn from_tokens(
+        tokens: &mut impl Tokens<'a>,
+        depth_limiter: DepthLimiter,
+    ) -> Result<Self, ParseError> {
         if let Some(open_span) = tokens.next_if_punctuator(PunctuatorType::OpenSquareBracket) {
-            let inner = Box::new(VariableType::from_tokens(tokens)?);
+            let inner = Box::new(VariableType::from_tokens(tokens, depth_limiter.bump()?)?);
             let close_span = tokens.expect_punctuator(PunctuatorType::CloseSquareBracket)?;
             let bang_span = tokens.next_if_punctuator(PunctuatorType::Bang);
             let is_required = bang_span.is_some();

--- a/bluejay-parser/src/ast/from_tokens.rs
+++ b/bluejay-parser/src/ast/from_tokens.rs
@@ -1,5 +1,8 @@
-use crate::ast::{ParseError, Tokens};
+use crate::ast::{DepthLimiter, ParseError, Tokens};
 
 pub trait FromTokens<'a>: Sized {
-    fn from_tokens(tokens: &mut impl Tokens<'a>) -> Result<Self, ParseError>;
+    fn from_tokens(
+        tokens: &mut impl Tokens<'a>,
+        depth_limiter: DepthLimiter,
+    ) -> Result<Self, ParseError>;
 }

--- a/bluejay-parser/src/ast/is_match.rs
+++ b/bluejay-parser/src/ast/is_match.rs
@@ -1,11 +1,14 @@
-use crate::ast::{FromTokens, ParseError, Tokens, TryFromTokens};
+use crate::ast::{DepthLimiter, FromTokens, ParseError, Tokens, TryFromTokens};
 
 pub trait IsMatch<'a> {
     fn is_match(tokens: &mut impl Tokens<'a>) -> bool;
 }
 
 impl<'a, T: FromTokens<'a> + IsMatch<'a>> TryFromTokens<'a> for T {
-    fn try_from_tokens(tokens: &mut impl Tokens<'a>) -> Option<Result<Self, ParseError>> {
-        Self::is_match(tokens).then(|| Self::from_tokens(tokens))
+    fn try_from_tokens(
+        tokens: &mut impl Tokens<'a>,
+        depth_limiter: DepthLimiter,
+    ) -> Option<Result<Self, ParseError>> {
+        Self::is_match(tokens).then(|| Self::from_tokens(tokens, depth_limiter))
     }
 }

--- a/bluejay-parser/src/ast/operation_type.rs
+++ b/bluejay-parser/src/ast/operation_type.rs
@@ -1,4 +1,4 @@
-use crate::ast::{FromTokens, IsMatch, ParseError, Tokens};
+use crate::ast::{DepthLimiter, FromTokens, IsMatch, ParseError, Tokens};
 use crate::{HasSpan, Span};
 
 #[derive(Debug)]
@@ -21,7 +21,7 @@ impl From<&OperationType> for bluejay_core::OperationType {
 
 impl<'a> FromTokens<'a> for OperationType {
     #[inline]
-    fn from_tokens(tokens: &mut impl Tokens<'a>) -> Result<Self, ParseError> {
+    fn from_tokens(tokens: &mut impl Tokens<'a>, _: DepthLimiter) -> Result<Self, ParseError> {
         tokens.expect_name().and_then(|name| {
             match bluejay_core::OperationType::try_from(name.as_str()) {
                 Ok(operation_type) => Ok(Self {

--- a/bluejay-parser/src/ast/parse_error.rs
+++ b/bluejay-parser/src/ast/parse_error.rs
@@ -25,6 +25,7 @@ pub enum ParseError {
         span: Span,
     },
     EmptyDocument,
+    MaxDepthExceeded,
 }
 
 impl From<ParseError> for Error {
@@ -71,6 +72,7 @@ impl From<ParseError> for Error {
                 None,
                 Vec::new(),
             ),
+            ParseError::MaxDepthExceeded => Self::new("Max depth exceeded", None, Vec::new()),
         }
     }
 }

--- a/bluejay-parser/src/ast/try_from_tokens.rs
+++ b/bluejay-parser/src/ast/try_from_tokens.rs
@@ -1,5 +1,8 @@
-use crate::ast::{ParseError, Tokens};
+use crate::ast::{DepthLimiter, ParseError, Tokens};
 
 pub trait TryFromTokens<'a>: Sized {
-    fn try_from_tokens(tokens: &mut impl Tokens<'a>) -> Option<Result<Self, ParseError>>;
+    fn try_from_tokens(
+        tokens: &mut impl Tokens<'a>,
+        depth_limiter: DepthLimiter,
+    ) -> Option<Result<Self, ParseError>>;
 }

--- a/bluejay-parser/tests/executable_document_integration_test.rs
+++ b/bluejay-parser/tests/executable_document_integration_test.rs
@@ -41,6 +41,7 @@ fn test_graphql_ruby_valid() {
                 input.as_str(),
                 ParseOptions {
                     graphql_ruby_compatibility: true,
+                    ..Default::default()
                 },
             );
             assert!(executable_document.is_ok(), "Document had errors");


### PR DESCRIPTION
Introduce a mechanism to prevent stack overflow for parsing very large documents.

Does 2000 seem like a reasonable default? Would there be a case where a valid document against a valid schema actually hit that?