### PR TITLE
Still return error when no annotations

### DIFF
--- a/bluejay-parser/src/error.rs
+++ b/bluejay-parser/src/error.rs
@@ -64,7 +64,7 @@ impl Error {
                         message: primary_annotation.message,
                         locations: vec![Location { line, col }],
                     }))
-                } else {
+                } else if !err.secondary_annotations.is_empty() {
                     Either::Right(err.secondary_annotations.into_iter().map(
                         |secondary_annotation| {
                             let (line, col) = converter
@@ -77,6 +77,11 @@ impl Error {
                             }
                         },
                     ))
+                } else {
+                    Either::Left(std::iter::once(GraphQLError {
+                        message: err.message,
+                        locations: vec![],
+                    }))
                 }
             })
             .collect()


### PR DESCRIPTION
Some errors have no primary or secondary annotations. We should still return an error in that case, just without a location