### PR TITLE
Expose borrow param

### DIFF
--- a/bluejay-typegen-codegen/src/input.rs
+++ b/bluejay-typegen-codegen/src/input.rs
@@ -63,7 +63,7 @@ impl DocumentInput {
 
 pub struct Input {
     pub(crate) schema: DocumentInput,
-    pub(crate) borrow: bool,
+    pub borrow: Option<syn::LitBool>,
     pub enums_as_str: syn::punctuated::Punctuated<syn::LitStr, syn::Token![,]>,
 }
 
@@ -90,7 +90,6 @@ impl Parse for Input {
             }
         }
 
-        let borrow = borrow.is_some_and(|borrow| borrow.value);
         let enums_as_str = enums_as_str.unwrap_or_default();
 
         Ok(Self {

--- a/bluejay-typegen-codegen/src/lib.rs
+++ b/bluejay-typegen-codegen/src/lib.rs
@@ -84,6 +84,8 @@ pub fn generate_schema(
         enums_as_str,
     } = input;
 
+    let borrow = borrow.is_some_and(|lit| lit.value());
+
     let (schema_contents, schema_path) = schema.read_to_string_and_path()?;
 
     let definition_document: DefinitionDocument = DefinitionDocument::parse(&schema_contents)


### PR DESCRIPTION
Make it possible for consumers to perform further validations on the value, such as erroring in the case that it is provided.