### PR TITLE
Support custom scalar overrides

### DIFF
--- a/bluejay-typegen-codegen/src/executable_definition.rs
+++ b/bluejay-typegen-codegen/src/executable_definition.rs
@@ -1,11 +1,14 @@
-use crate::{map_parser_errors, validation, CodeGenerator, Config, DocumentInput};
+use crate::{
+    input::parse_key_value_with, map_parser_errors, validation, CodeGenerator, Config,
+    DocumentInput,
+};
 use bluejay_core::definition::SchemaDefinition;
 use bluejay_parser::ast::{executable::ExecutableDocument, Parse as _};
 use bluejay_validator::executable::{
     document::{BuiltinRulesValidator, Orchestrator},
     Cache,
 };
-use syn::{parse::Parse, parse2};
+use syn::{parse::Parse, parse2, spanned::Spanned};
 
 mod executable_enum_builder;
 mod executable_enum_variant_builder;
@@ -21,14 +24,114 @@ pub use intermediate_representation::{
     ExecutableEnum, ExecutableField, ExecutableStruct, ExecutableType, WrappedExecutableType,
 };
 
+mod kw {
+    syn::custom_keyword!(custom_scalar_overrides);
+}
+
+pub(crate) struct CustomScalarOverride {
+    #[allow(unused)]
+    graphql_path_token: syn::LitStr,
+    graphql_path: Vec<String>,
+    type_token: syn::Type,
+    borrows: bool,
+}
+
+impl Parse for CustomScalarOverride {
+    fn parse(input: syn::parse::ParseStream) -> syn::Result<Self> {
+        let graphql_path_token = input.parse()?;
+        let graphql_path = Self::graphql_path(&graphql_path_token);
+        input.parse::<syn::Token![=>]>()?;
+        let type_token = input.parse()?;
+
+        let borrows = Self::path_borrows(&type_token)?;
+
+        Ok(Self {
+            graphql_path_token,
+            graphql_path,
+            type_token,
+            borrows,
+        })
+    }
+}
+
+impl CustomScalarOverride {
+    fn graphql_path(lit_str: &syn::LitStr) -> Vec<String> {
+        lit_str.value().split('.').map(|s| s.to_string()).collect()
+    }
+
+    fn path_borrows(path: &syn::Type) -> syn::Result<bool> {
+        let syn::Type::Path(path) = path else {
+            return Ok(false);
+        };
+
+        let Some(last_segment) = path.path.segments.last() else {
+            return Err(syn::Error::new(
+                path.span(),
+                "Path must have at least one segment",
+            ));
+        };
+
+        let path_arguments = match &last_segment.arguments {
+            syn::PathArguments::None => return Ok(false),
+            syn::PathArguments::AngleBracketed(bracketed) => bracketed,
+            syn::PathArguments::Parenthesized(parenthesized) => {
+                return Err(syn::Error::new(
+                    parenthesized.span(),
+                    "Paths for custom scalar overrides must not contain parenthesized generic arguments",
+                ));
+            }
+        };
+
+        if path_arguments.args.len() != 1
+            || !matches!(
+                path_arguments.args.first(),
+                Some(syn::GenericArgument::Lifetime(lifetime)) if lifetime.ident != "a"
+            )
+        {
+            return Err(syn::Error::new(
+                path.span(),
+                "Paths for custom scalar overrides with generic arguments must contain a single lifetime parameter",
+            ));
+        }
+
+        Ok(true)
+    }
+
+    fn r#type(&self) -> &syn::Type {
+        &self.type_token
+    }
+}
+
 struct Input {
     query: DocumentInput,
+    custom_scalar_overrides:
+        Option<syn::punctuated::Punctuated<CustomScalarOverride, syn::Token![,]>>,
 }
 
 impl Parse for Input {
     fn parse(input: syn::parse::ParseStream) -> syn::Result<Self> {
         let query = input.parse()?;
-        Ok(Self { query })
+
+        let mut custom_scalar_overrides = None;
+
+        while !input.is_empty() {
+            input.parse::<syn::Token![,]>()?;
+            let lookahead = input.lookahead1();
+            if lookahead.peek(kw::custom_scalar_overrides) {
+                parse_key_value_with(input, &mut custom_scalar_overrides, |input| {
+                    let content;
+                    syn::braced!(content in input);
+                    syn::punctuated::Punctuated::parse_terminated(&content)
+                })?;
+            } else {
+                return Err(lookahead.error());
+            }
+        }
+
+        Ok(Self {
+            query,
+            custom_scalar_overrides,
+        })
     }
 }
 
@@ -36,7 +139,10 @@ pub(crate) fn generate_executable_definition<S: SchemaDefinition, C: CodeGenerat
     config: &Config<S, C>,
     configuration: proc_macro2::TokenStream,
 ) -> syn::Result<Vec<syn::Item>> {
-    let Input { query } = parse2(configuration)?;
+    let Input {
+        query,
+        custom_scalar_overrides,
+    } = parse2(configuration)?;
 
     let (contents, path) = query.read_to_string_and_path()?;
 
@@ -57,12 +163,21 @@ pub(crate) fn generate_executable_definition<S: SchemaDefinition, C: CodeGenerat
             validation_errors,
         ));
     }
-    let validation_errors: Vec<_> = Orchestrator::<_, _, validation::Rule<_, _>>::validate(
+    let (validation_errors, paths_with_custom_scalar_type) = Orchestrator::<
+        _,
+        _,
+        (
+            validation::Rule<_, _>,
+            validation::PathsWithCustomScalarType<_>,
+        ),
+    >::validate_and_analyze(
         &executable_document,
         config.schema_definition(),
         &validation_cache,
-    )
-    .collect();
+    );
+
+    let validation_errors: Vec<_> = validation_errors.collect();
+
     if !validation_errors.is_empty() {
         return Err(map_parser_errors(
             &query,
@@ -72,7 +187,27 @@ pub(crate) fn generate_executable_definition<S: SchemaDefinition, C: CodeGenerat
         ));
     }
 
-    let executable_types = ExecutableType::for_executable_document(&executable_document, config);
+    let custom_scalar_overrides: Vec<CustomScalarOverride> = custom_scalar_overrides
+        .map(|c| c.into_iter().collect())
+        .unwrap_or_default();
+
+    let (valid_custom_scalar_overrides, invalid_custom_scalar_overrides): (Vec<_>, Vec<_>) =
+        custom_scalar_overrides
+            .into_iter()
+            .partition(|c| paths_with_custom_scalar_type.contains(&c.graphql_path));
+
+    if let Some(invalid_custom_scalar_override) = invalid_custom_scalar_overrides.first() {
+        return Err(syn::Error::new(
+            invalid_custom_scalar_override.graphql_path_token.span(),
+            "Custom scalar overrides must correspond to a path in the query that is a custom scalar type",
+        ));
+    }
+
+    let executable_types = ExecutableType::for_executable_document(
+        &executable_document,
+        config,
+        valid_custom_scalar_overrides,
+    );
 
     Ok(executable_types
         .iter()

--- a/bluejay-typegen-codegen/src/executable_definition.rs
+++ b/bluejay-typegen-codegen/src/executable_definition.rs
@@ -29,7 +29,6 @@ mod kw {
 }
 
 pub(crate) struct CustomScalarOverride {
-    #[allow(unused)]
     graphql_path_token: syn::LitStr,
     graphql_path: Vec<String>,
     type_token: syn::Type,

--- a/bluejay-typegen-codegen/src/executable_definition.rs
+++ b/bluejay-typegen-codegen/src/executable_definition.rs
@@ -60,14 +60,16 @@ impl CustomScalarOverride {
     }
 
     fn type_borrows(ty: &syn::Type) -> syn::Result<bool> {
-        let syn::Type::Path(path) = ty else {
-            // in the future, we could support arrays and tuples, but it is complex to
-            // resolve the relative path with composite types like these so for simplicity
-            // we don't support them
-            return Err(syn::Error::new(
-                ty.span(),
-                "Unsupported type for custom scalar overrides",
-            ));
+        let path = match ty {
+            syn::Type::Path(path) => path,
+            // allow the `()` type
+            syn::Type::Tuple(tuple) if tuple.elems.is_empty() => return Ok(false),
+            _ => {
+                return Err(syn::Error::new(
+                    ty.span(),
+                    "Unsupported type for custom scalar overrides",
+                ));
+            }
         };
 
         let Some(last_segment) = path.path.segments.last() else {

--- a/bluejay-typegen-codegen/src/input.rs
+++ b/bluejay-typegen-codegen/src/input.rs
@@ -78,9 +78,9 @@ impl Parse for Input {
             input.parse::<syn::Token![,]>()?;
             let lookahead = input.lookahead1();
             if lookahead.peek(kw::borrow) {
-                Self::parse_key_value(input, &mut borrow)?;
+                parse_key_value(input, &mut borrow)?;
             } else if lookahead.peek(kw::enums_as_str) {
-                Self::parse_key_value_with(input, &mut enums_as_str, |input| {
+                parse_key_value_with(input, &mut enums_as_str, |input| {
                     let content;
                     syn::bracketed!(content in input);
                     syn::punctuated::Punctuated::parse_separated_nonempty(&content)
@@ -101,30 +101,28 @@ impl Parse for Input {
     }
 }
 
-impl Input {
-    fn parse_key_value<V: syn::parse::Parse>(
-        input: syn::parse::ParseStream,
-        value: &mut Option<V>,
-    ) -> syn::Result<()> {
-        Self::parse_key_value_with(input, value, syn::parse::Parse::parse)
+fn parse_key_value<V: syn::parse::Parse>(
+    input: syn::parse::ParseStream,
+    value: &mut Option<V>,
+) -> syn::Result<()> {
+    parse_key_value_with(input, value, syn::parse::Parse::parse)
+}
+
+pub(crate) fn parse_key_value_with<V>(
+    input: syn::parse::ParseStream,
+    value: &mut Option<V>,
+    parser: fn(syn::parse::ParseStream<'_>) -> syn::Result<V>,
+) -> syn::Result<()> {
+    let key: syn::Ident = input.parse()?;
+
+    if value.is_some() {
+        return Err(syn::Error::new(
+            key.span(),
+            format!("Duplicate entry for `{}`", key),
+        ));
     }
 
-    fn parse_key_value_with<V>(
-        input: syn::parse::ParseStream,
-        value: &mut Option<V>,
-        parser: fn(syn::parse::ParseStream<'_>) -> syn::Result<V>,
-    ) -> syn::Result<()> {
-        let key: syn::Ident = input.parse()?;
-
-        if value.is_some() {
-            return Err(syn::Error::new(
-                key.span(),
-                format!("Duplicate entry for `{}`", key),
-            ));
-        }
-
-        input.parse::<syn::Token![=]>()?;
-        *value = Some(parser(input)?);
-        Ok(())
-    }
+    input.parse::<syn::Token![=]>()?;
+    *value = Some(parser(input)?);
+    Ok(())
 }

--- a/bluejay-typegen-codegen/src/validation.rs
+++ b/bluejay-typegen-codegen/src/validation.rs
@@ -1,5 +1,6 @@
 mod error;
 mod fragment_and_operation_names_do_not_clash;
+mod paths_with_custom_scalar_type;
 mod selections_are_valid;
 
 use error::Error;
@@ -10,3 +11,5 @@ pub(crate) type Rule<'a, E, S> = (
     SelectionsAreValid<'a, E, S>,
     FragmentAndOperationNamesDoNotClash<'a, E, S>,
 );
+
+pub(crate) use paths_with_custom_scalar_type::PathsWithCustomScalarType;

--- a/bluejay-typegen-codegen/src/validation/paths_with_custom_scalar_type.rs
+++ b/bluejay-typegen-codegen/src/validation/paths_with_custom_scalar_type.rs
@@ -1,0 +1,60 @@
+use bluejay_core::{
+    definition::{prelude::*, BaseOutputTypeReference, SchemaDefinition},
+    executable::{ExecutableDocument, Field, Selection, SelectionReference},
+};
+use bluejay_validator::executable::{
+    document::{Analyzer, Path, Visitor},
+    Cache,
+};
+use std::collections::HashSet;
+
+pub(crate) struct PathsWithCustomScalarType<'a, S: SchemaDefinition> {
+    schema_definition: &'a S,
+    paths: HashSet<Vec<String>>,
+}
+
+impl<'a, E: ExecutableDocument, S: SchemaDefinition> Visitor<'a, E, S>
+    for PathsWithCustomScalarType<'a, S>
+{
+    fn new(_: &'a E, schema_definition: &'a S, _: &'a Cache<'a, E, S>) -> Self {
+        Self {
+            schema_definition,
+            paths: HashSet::new(),
+        }
+    }
+
+    fn visit_field(
+        &mut self,
+        _field: &'a <E as ExecutableDocument>::Field,
+        field_definition: &'a <S as SchemaDefinition>::FieldDefinition,
+        path: &Path<'a, E>,
+    ) {
+        if matches!(
+            field_definition.r#type().base(self.schema_definition),
+            BaseOutputTypeReference::CustomScalar(_)
+        ) {
+            if let Some(root_name) = path.root().name() {
+                self.paths.insert(
+                    std::iter::once(root_name.to_string())
+                        .chain(path.members().iter().filter_map(
+                            |selection| match selection.as_ref() {
+                                SelectionReference::Field(f) => Some(f.response_name().to_string()),
+                                _ => None,
+                            },
+                        ))
+                        .collect(),
+                );
+            }
+        }
+    }
+}
+
+impl<'a, E: ExecutableDocument, S: SchemaDefinition> Analyzer<'a, E, S>
+    for PathsWithCustomScalarType<'a, S>
+{
+    type Output = HashSet<Vec<String>>;
+
+    fn into_output(self) -> Self::Output {
+        self.paths
+    }
+}

--- a/bluejay-typegen-macro/src/lib.rs
+++ b/bluejay-typegen-macro/src/lib.rs
@@ -31,9 +31,32 @@ use syn::{parse_macro_input, parse_quote};
 /// ### Usage
 ///
 /// Must be used with a module. Inside the module, type aliases must be defined for any custom scalars in the schema.
+///
+/// #### Queries
+///
 /// To use a query, define a module within the aforementioned module, and annotate it with
 /// `#[query("path/to/query.graphql")]`, where the argument is a string literal path to the query document, or the
 /// query contents enclosed in square brackets.
+///
+/// ##### Custom scalar overrides
+///
+/// To override the type of a custom scalar for a path within a query, use the `custom_scalar_overrides` named argument
+/// inside of the `#[query(...)]` attribute. The argument is a map from a path to a type, where the path is a string literal
+/// path to the field in the query, and the type is the type to override the field with.
+///
+/// For example, with the following query:
+/// ```graphql
+/// query MyQuery {
+///     myField: myScalar!
+/// }
+/// ```
+/// do something like the following:
+/// ```ignore
+/// #[query("path/to/query.graphql", custom_scalar_overrides = {
+///     "MyQuery.myField" => ::std::primitive::i32,
+/// })]
+/// ```
+/// Any type path that does not start with `::` is assumed to be relative to the schema definition module.
 ///
 /// ### Naming
 ///

--- a/bluejay-typegen-macro/src/lib.rs
+++ b/bluejay-typegen-macro/src/lib.rs
@@ -57,6 +57,9 @@ use syn::{parse_macro_input, parse_quote};
 /// })]
 /// ```
 /// Any type path that does not start with `::` is assumed to be relative to the schema definition module.
+/// Types may have a single lifetime parameter, which must be named `a`. Generic types are not supported.
+/// If you need to use a generic type, use an alias for the type to remove the generic parameters.
+/// Arrays and tuples are not supported.
 ///
 /// ### Naming
 ///

--- a/bluejay-typegen/examples/input.graphql
+++ b/bluejay-typegen/examples/input.graphql
@@ -5,4 +5,9 @@ query Input {
       quantity
     }
   }
+  discountNode {
+    configuration: metafield(namespace: "my-namespace", key: "my-key") {
+      jsonValue
+    }
+  }
 }

--- a/bluejay-typegen/examples/input.json
+++ b/bluejay-typegen/examples/input.json
@@ -6,5 +6,12 @@
         "quantity": 2
       }
     ]
+  },
+  "discountNode": {
+    "configuration": {
+      "jsonValue": {
+        "thresholdQuantity": 1
+      }
+    }
   }
 }

--- a/bluejay-typegen/examples/query.graphql
+++ b/bluejay-typegen/examples/query.graphql
@@ -1,8 +1,0 @@
-query Input {
-  cart {
-    lines {
-      id
-      quantity
-    }
-  }
-}

--- a/bluejay-typegen/examples/schema.graphql
+++ b/bluejay-typegen/examples/schema.graphql
@@ -4,21 +4,26 @@ schema {
 }
 
 """
-Exactly one field of input must be provided, and all others omitted.
+Scale the Functions resource limits based on the field's length.
+"""
+directive @scaleLimits(rate: Float!) on FIELD_DEFINITION
+
+"""
+Requires that exactly one field must be supplied and that field must not be `null`.
 """
 directive @oneOf on INPUT_OBJECT
 
 """
-Represents a generic custom attribute.
+Represents a generic custom attribute, such as whether an order is a customer's first.
 """
 type Attribute {
   """
-  Key or name of the attribute.
+  The key or name of the attribute. For example, `"customersFirstOrder"`.
   """
   key: String!
 
   """
-  Value of the attribute.
+  The value of the attribute. For example, `"true"`.
   """
   value: String
 }
@@ -90,7 +95,17 @@ type Cart {
   """
   A list of lines containing information about the items the customer intends to purchase.
   """
-  lines: [CartLine!]!
+  lines: [CartLine!]! @scaleLimits(rate: 0.005)
+
+  """
+  The localized fields available for the cart.
+  """
+  localizedFields(
+    """
+    The keys of the localized fields to retrieve.
+    """
+    keys: [LocalizedFieldKey!]! = []
+  ): [LocalizedField!]!
 }
 
 """
@@ -125,7 +140,7 @@ type CartDeliveryGroup {
   """
   A list of cart lines for the delivery group.
   """
-  cartLines: [CartLine!]!
+  cartLines: [CartLine!]! @scaleLimits(rate: 0.005)
 
   """
   The destination address for the delivery group.
@@ -175,7 +190,7 @@ type CartDeliveryOption {
   """
   The unique identifier of the delivery option.
   """
-  handle: String!
+  handle: Handle!
 
   """
   The title of the delivery option.
@@ -236,7 +251,8 @@ type CartLineCost {
   amountPerQuantity: MoneyV2!
 
   """
-  The compare at amount of the merchandise line.
+  The compare at amount of the merchandise line. This value varies depending on
+  the buyer's identity, and is null when the value is hidden to buyers.
   """
   compareAtAmountPerQuantity: MoneyV2
 
@@ -249,6 +265,24 @@ type CartLineCost {
   The total cost of the merchandise line.
   """
   totalAmount: MoneyV2!
+}
+
+"""
+A discount [Target](https://shopify.dev/api/functions/reference/product-discounts/graphql/common-objects/target) that applies to a specific cart line, up to an optional quantity limit.
+"""
+input CartLineTarget {
+  """
+  The ID of the targeted cart line.
+  """
+  id: ID!
+
+  """
+  The number of line items that are being discounted.
+  The default value is `null`, which represents the quantity of the matching line items.
+
+  The value is validated against: > 0.
+  """
+  quantity: Int
 }
 
 """
@@ -1508,7 +1542,7 @@ enum CountryCode {
   TO
 
   """
-  Turkey.
+  Türkiye.
   """
   TR
 
@@ -2390,7 +2424,7 @@ enum CurrencyCode {
   VEF @deprecated(reason: "`VEF` is deprecated. Use `VES` available from version `2020-10` onwards instead.")
 
   """
-  Venezuelan Bolivares (VES).
+  Venezuelan Bolivares Soberanos (VES).
   """
   VES
 
@@ -2501,6 +2535,11 @@ type Customer implements HasMetafields {
   email: String
 
   """
+  The customer's first name.
+  """
+  firstName: String
+
+  """
   Whether the customer has any of the given tags.
   """
   hasAnyTag(
@@ -2524,6 +2563,11 @@ type Customer implements HasMetafields {
   A unique identifier for the customer.
   """
   id: ID!
+
+  """
+  The customer's last name.
+  """
+  lastName: String
 
   """
   Returns a metafield by namespace and key that belongs to the resource.
@@ -2652,6 +2696,8 @@ input Discount {
 
   """
   The targets of the discount.
+
+  This argument accepts a collection of either `ProductVariantTarget`s or `CartLineTarget`s, but not both.
   """
   targets: [Target!]!
 
@@ -2665,6 +2711,11 @@ input Discount {
 The strategy that's applied to the list of discounts.
 """
 enum DiscountApplicationStrategy {
+  """
+  Apply all discounts with conditions that are satisfied. This does not override discount combination or stacking rules.
+  """
+  ALL
+
   """
   Only apply the first discount with conditions that are satisfied.
   """
@@ -2717,7 +2768,7 @@ input FixedAmount {
 }
 
 """
-The result of the function. This type is deprecated in favor of `FunctionRunResult`.
+The run target result. In API versions 2023-10 and beyond, this type is deprecated in favor of `FunctionRunResult`.
 """
 input FunctionResult {
   """
@@ -2732,7 +2783,7 @@ input FunctionResult {
 }
 
 """
-The result of the function.
+The run target result.
 """
 input FunctionRunResult {
   """
@@ -2745,6 +2796,13 @@ input FunctionRunResult {
   """
   discounts: [Discount!]!
 }
+
+"""
+A function-scoped handle to a refer a resource.
+The Handle type appears in a JSON response as a String, but it is not intended to be human-readable.
+Example value: `"10079785100"`
+"""
+scalar Handle
 
 """
 Represents information about the metafields associated to the specified resource.
@@ -2820,6 +2878,23 @@ type Input {
 }
 
 """
+A [JSON](https://www.json.org/json-en.html) object.
+
+Example value:
+`{
+  "product": {
+    "id": "gid://shopify/Product/1346443542550",
+    "title": "White T-shirt",
+    "options": [{
+      "name": "Size",
+      "values": ["M", "L"]
+    }]
+  }
+}`
+"""
+scalar JSON
+
+"""
 A language.
 """
 type Language {
@@ -2830,7 +2905,7 @@ type Language {
 }
 
 """
-ISO 639-1 language codes supported by Shopify.
+Language codes supported by Shopify.
 """
 enum LanguageCode {
   """
@@ -2907,6 +2982,11 @@ enum LanguageCode {
   Chechen.
   """
   CE
+
+  """
+  Central Kurdish.
+  """
+  CKB
 
   """
   Czech.
@@ -2987,6 +3067,11 @@ enum LanguageCode {
   Finnish.
   """
   FI
+
+  """
+  Filipino.
+  """
+  FIL
 
   """
   Faroese.
@@ -3339,6 +3424,16 @@ enum LanguageCode {
   RW
 
   """
+  Sanskrit.
+  """
+  SA
+
+  """
+  Sardinian.
+  """
+  SC
+
+  """
   Sindhi.
   """
   SD
@@ -3620,6 +3715,219 @@ type Localization {
 }
 
 """
+Represents the value captured by a localized field. Localized fields are
+additional fields required by certain countries on international orders. For
+example, some countries require additional fields for customs information or tax
+identification numbers.
+"""
+type LocalizedField {
+  """
+  The key of the localized field.
+  """
+  key: LocalizedFieldKey!
+
+  """
+  The title of the localized field.
+  """
+  title: String!
+
+  """
+  The value of the localized field.
+  """
+  value: String
+}
+
+"""
+Unique key identifying localized fields.
+"""
+enum LocalizedFieldKey {
+  """
+  Localized field key 'shipping_credential_br' for country BR.
+  """
+  SHIPPING_CREDENTIAL_BR
+
+  """
+  Localized field key 'shipping_credential_cl' for country CL.
+  """
+  SHIPPING_CREDENTIAL_CL
+
+  """
+  Localized field key 'shipping_credential_cn' for country CN.
+  """
+  SHIPPING_CREDENTIAL_CN
+
+  """
+  Localized field key 'shipping_credential_co' for country CO.
+  """
+  SHIPPING_CREDENTIAL_CO
+
+  """
+  Localized field key 'shipping_credential_cr' for country CR.
+  """
+  SHIPPING_CREDENTIAL_CR
+
+  """
+  Localized field key 'shipping_credential_ec' for country EC.
+  """
+  SHIPPING_CREDENTIAL_EC
+
+  """
+  Localized field key 'shipping_credential_es' for country ES.
+  """
+  SHIPPING_CREDENTIAL_ES
+
+  """
+  Localized field key 'shipping_credential_gt' for country GT.
+  """
+  SHIPPING_CREDENTIAL_GT
+
+  """
+  Localized field key 'shipping_credential_id' for country ID.
+  """
+  SHIPPING_CREDENTIAL_ID
+
+  """
+  Localized field key 'shipping_credential_kr' for country KR.
+  """
+  SHIPPING_CREDENTIAL_KR
+
+  """
+  Localized field key 'shipping_credential_mx' for country MX.
+  """
+  SHIPPING_CREDENTIAL_MX
+
+  """
+  Localized field key 'shipping_credential_my' for country MY.
+  """
+  SHIPPING_CREDENTIAL_MY
+
+  """
+  Localized field key 'shipping_credential_pe' for country PE.
+  """
+  SHIPPING_CREDENTIAL_PE
+
+  """
+  Localized field key 'shipping_credential_pt' for country PT.
+  """
+  SHIPPING_CREDENTIAL_PT
+
+  """
+  Localized field key 'shipping_credential_py' for country PY.
+  """
+  SHIPPING_CREDENTIAL_PY
+
+  """
+  Localized field key 'shipping_credential_tr' for country TR.
+  """
+  SHIPPING_CREDENTIAL_TR
+
+  """
+  Localized field key 'shipping_credential_tw' for country TW.
+  """
+  SHIPPING_CREDENTIAL_TW
+
+  """
+  Localized field key 'shipping_credential_type_co' for country CO.
+  """
+  SHIPPING_CREDENTIAL_TYPE_CO
+
+  """
+  Localized field key 'tax_credential_br' for country BR.
+  """
+  TAX_CREDENTIAL_BR
+
+  """
+  Localized field key 'tax_credential_cl' for country CL.
+  """
+  TAX_CREDENTIAL_CL
+
+  """
+  Localized field key 'tax_credential_co' for country CO.
+  """
+  TAX_CREDENTIAL_CO
+
+  """
+  Localized field key 'tax_credential_cr' for country CR.
+  """
+  TAX_CREDENTIAL_CR
+
+  """
+  Localized field key 'tax_credential_ec' for country EC.
+  """
+  TAX_CREDENTIAL_EC
+
+  """
+  Localized field key 'tax_credential_es' for country ES.
+  """
+  TAX_CREDENTIAL_ES
+
+  """
+  Localized field key 'tax_credential_gt' for country GT.
+  """
+  TAX_CREDENTIAL_GT
+
+  """
+  Localized field key 'tax_credential_id' for country ID.
+  """
+  TAX_CREDENTIAL_ID
+
+  """
+  Localized field key 'tax_credential_it' for country IT.
+  """
+  TAX_CREDENTIAL_IT
+
+  """
+  Localized field key 'tax_credential_mx' for country MX.
+  """
+  TAX_CREDENTIAL_MX
+
+  """
+  Localized field key 'tax_credential_my' for country MY.
+  """
+  TAX_CREDENTIAL_MY
+
+  """
+  Localized field key 'tax_credential_pe' for country PE.
+  """
+  TAX_CREDENTIAL_PE
+
+  """
+  Localized field key 'tax_credential_pt' for country PT.
+  """
+  TAX_CREDENTIAL_PT
+
+  """
+  Localized field key 'tax_credential_py' for country PY.
+  """
+  TAX_CREDENTIAL_PY
+
+  """
+  Localized field key 'tax_credential_tr' for country TR.
+  """
+  TAX_CREDENTIAL_TR
+
+  """
+  Localized field key 'tax_credential_type_co' for country CO.
+  """
+  TAX_CREDENTIAL_TYPE_CO
+
+  """
+  Localized field key 'tax_credential_type_mx' for country MX.
+  """
+  TAX_CREDENTIAL_TYPE_MX
+
+  """
+  Localized field key 'tax_credential_use_mx' for country MX.
+  """
+  TAX_CREDENTIAL_USE_MX
+
+  """
+  Localized field key 'tax_email_it' for country IT.
+  """
+  TAX_EMAIL_IT
+}
+
+"""
 Represents a mailing address.
 """
 type MailingAddress {
@@ -3684,7 +3992,7 @@ type MailingAddress {
   phone: String
 
   """
-  The two-letter code for the region. For example, ON.
+  The alphanumeric code for the region. For example, ON.
   """
   provinceCode: String
 
@@ -3706,7 +4014,7 @@ type Market implements HasMetafields {
   """
   A human-readable unique string for the market automatically generated from its title.
   """
-  handle: String!
+  handle: Handle!
 
   """
   A globally-unique identifier.
@@ -3774,13 +4082,18 @@ For more information about the Shopify resources that you can attach metafields 
 """
 type Metafield {
   """
+  The data stored in the metafield in JSON format.
+  """
+  jsonValue: JSON!
+
+  """
   The type of data that the metafield stores in the `value` field.
   Refer to the list of [supported types](https://shopify.dev/apps/metafields/types).
   """
   type: String!
 
   """
-  The data to store in the metafield. The data is always stored as a string, regardless of the metafield's type.
+  The data stored in the metafield. Always stored as a string, regardless of the metafield's type.
   """
   value: String!
 }
@@ -3832,7 +4145,7 @@ input Percentage {
   """
   The percentage value.
 
-  The value is validated against: >= 0.
+  The value is validated against: >= 0 and <= 100.
   """
   value: Decimal!
 }
@@ -3844,7 +4157,7 @@ type Product implements HasMetafields {
   """
   A unique human-friendly string of the product's title.
   """
-  handle: String!
+  handle: Handle!
 
   """
   Whether the product has any of the given tags.
@@ -3983,17 +4296,18 @@ type ProductVariant implements HasMetafields {
 }
 
 """
-The target product variant.
+A discount [Target](https://shopify.dev/api/functions/reference/product-discounts/graphql/common-objects/target) that can apply to any cart lines for a specific product variant, up to an
+optional quantity limit.
 """
 input ProductVariantTarget {
   """
-  The ID of the target product variant.
+  The ID of the targeted product variant.
   """
   id: ID!
 
   """
-  The number of line items that are being discounted.
-  The default value is `null`, which represents the quantity of the matching line items.
+  The maximum number of line item units to be discounted.
+  The default value is `null`, which represents the total quantity of the matching line items.
 
   The value is validated against: > 0.
   """
@@ -4023,7 +4337,7 @@ type PurchasingCompany {
 """
 Represents how products and variants can be sold and purchased.
 """
-type SellingPlan {
+type SellingPlan implements HasMetafields {
   """
   The description of the selling plan.
   """
@@ -4033,6 +4347,21 @@ type SellingPlan {
   A globally-unique identifier.
   """
   id: ID!
+
+  """
+  Returns a metafield by namespace and key that belongs to the resource.
+  """
+  metafield(
+    """
+    The key for the metafield.
+    """
+    key: String!
+
+    """
+    The container the metafield belongs to. If omitted, the app-reserved namespace will be used.
+    """
+    namespace: String
+  ): Metafield
 
   """
   The name of the selling plan. For example, '6 weeks of prepaid granola, delivered weekly'.
@@ -4114,11 +4443,24 @@ type Shop implements HasMetafields {
 }
 
 """
-The target of the discount.
+A target of a discount, which determines which cart line(s) the discount will affect.
+
+A discount can have a collection of either `ProductVariantTarget`s or `CartLineTarget`s, but not both.
+
+Multiple targets with the same type and ID are the same as a single target of that type and ID with their
+quantities added together, or `null` if any of those targets have a quantity of `null`.
+
+See the [Product Discount API reference](https://shopify.dev/docs/api/functions/reference/product-discounts/graphql#functionrunresult) for examples.
 """
 input Target @oneOf {
   """
-  The target product variant.
+  A discount [Target](https://shopify.dev/api/functions/reference/product-discounts/graphql/common-objects/target) that applies to a specific cart line, up to an optional quantity limit.
+  """
+  cartLine: CartLineTarget
+
+  """
+  A discount [Target](https://shopify.dev/api/functions/reference/product-discounts/graphql/common-objects/target) that can apply to any cart lines for a specific product variant, up to an
+  optional quantity limit.
   """
   productVariant: ProductVariantTarget
 }

--- a/bluejay-typegen/tests/validation_cases/error/invalid_custom_scalar_overrides.rs
+++ b/bluejay-typegen/tests/validation_cases/error/invalid_custom_scalar_overrides.rs
@@ -9,8 +9,12 @@ mod schema {
     #[query([
         query MyQuery {
             myField
+            myOtherField: myField
         }
-    ], custom_scalar_overrides = { "MyQuery.myField" => super::MyScalarOverride })]
+    ], custom_scalar_overrides = {
+        "MyQuery.myField" => super::MyScalarOverride,
+        "MyQuery.myOtherField" => ::std::primitive::i32,
+    })]
     mod query {}
 }
 

--- a/bluejay-typegen/tests/validation_cases/error/invalid_custom_scalar_overrides.rs
+++ b/bluejay-typegen/tests/validation_cases/error/invalid_custom_scalar_overrides.rs
@@ -1,19 +1,27 @@
 type MyScalarOverride = String;
+type StringCow<'a> = std::borrow::Cow<'a, str>;
 
 #[bluejay_typegen::typegen([
+    scalar MyScalar
+
     type Query {
         myField: Int
+        myScalarField: MyScalar
     }
 ])]
 mod schema {
+    type MyScalar = String;
+
     #[query([
         query MyQuery {
             myField
             myOtherField: myField
+            myScalarField
         }
     ], custom_scalar_overrides = {
         "MyQuery.myField" => super::MyScalarOverride,
         "MyQuery.myOtherField" => ::std::primitive::i32,
+        "MyQuery.myScalarField" => super::StringCow<'a>,
     })]
     mod query {}
 }

--- a/bluejay-typegen/tests/validation_cases/error/invalid_custom_scalar_overrides.rs
+++ b/bluejay-typegen/tests/validation_cases/error/invalid_custom_scalar_overrides.rs
@@ -1,0 +1,17 @@
+type MyScalarOverride = String;
+
+#[bluejay_typegen::typegen([
+    type Query {
+        myField: Int
+    }
+])]
+mod schema {
+    #[query([
+        query MyQuery {
+            myField
+        }
+    ], custom_scalar_overrides = { "MyQuery.myField" => super::MyScalarOverride })]
+    mod query {}
+}
+
+fn main() {}

--- a/bluejay-typegen/tests/validation_cases/error/invalid_custom_scalar_overrides.stderr
+++ b/bluejay-typegen/tests/validation_cases/error/invalid_custom_scalar_overrides.stderr
@@ -1,0 +1,5 @@
+error: Custom scalar overrides must correspond to a path in the query that is a custom scalar type
+  --> tests/validation_cases/error/invalid_custom_scalar_overrides.rs:13:36
+   |
+13 |     ], custom_scalar_overrides = { "MyQuery.myField" => super::MyScalarOverride })]
+   |                                    ^^^^^^^^^^^^^^^^^

--- a/bluejay-typegen/tests/validation_cases/error/invalid_custom_scalar_overrides.stderr
+++ b/bluejay-typegen/tests/validation_cases/error/invalid_custom_scalar_overrides.stderr
@@ -1,5 +1,11 @@
 error: Custom scalar overrides must correspond to a path in the query that is a custom scalar type
-  --> tests/validation_cases/error/invalid_custom_scalar_overrides.rs:13:36
+  --> tests/validation_cases/error/invalid_custom_scalar_overrides.rs:15:9
    |
-13 |     ], custom_scalar_overrides = { "MyQuery.myField" => super::MyScalarOverride })]
-   |                                    ^^^^^^^^^^^^^^^^^
+15 |         "MyQuery.myField" => super::MyScalarOverride,
+   |         ^^^^^^^^^^^^^^^^^
+
+error: Custom scalar overrides must correspond to a path in the query that is a custom scalar type
+  --> tests/validation_cases/error/invalid_custom_scalar_overrides.rs:16:9
+   |
+16 |         "MyQuery.myOtherField" => ::std::primitive::i32,
+   |         ^^^^^^^^^^^^^^^^^^^^^^

--- a/bluejay-typegen/tests/validation_cases/error/invalid_custom_scalar_overrides.stderr
+++ b/bluejay-typegen/tests/validation_cases/error/invalid_custom_scalar_overrides.stderr
@@ -1,11 +1,17 @@
 error: Custom scalar overrides must correspond to a path in the query that is a custom scalar type
-  --> tests/validation_cases/error/invalid_custom_scalar_overrides.rs:15:9
+  --> tests/validation_cases/error/invalid_custom_scalar_overrides.rs:22:9
    |
-15 |         "MyQuery.myField" => super::MyScalarOverride,
+22 |         "MyQuery.myField" => super::MyScalarOverride,
    |         ^^^^^^^^^^^^^^^^^
 
 error: Custom scalar overrides must correspond to a path in the query that is a custom scalar type
-  --> tests/validation_cases/error/invalid_custom_scalar_overrides.rs:16:9
+  --> tests/validation_cases/error/invalid_custom_scalar_overrides.rs:23:9
    |
-16 |         "MyQuery.myOtherField" => ::std::primitive::i32,
+23 |         "MyQuery.myOtherField" => ::std::primitive::i32,
    |         ^^^^^^^^^^^^^^^^^^^^^^
+
+error: Custom scalar overrides must not borrow if the `borrow` option is not enabled
+  --> tests/validation_cases/error/invalid_custom_scalar_overrides.rs:24:36
+   |
+24 |         "MyQuery.myScalarField" => super::StringCow<'a>,
+   |                                    ^^^^^

--- a/bluejay-typegen/tests/validation_cases/valid/valid_custom_scalar_override.rs
+++ b/bluejay-typegen/tests/validation_cases/valid/valid_custom_scalar_override.rs
@@ -1,0 +1,33 @@
+type MyScalarOverride = String;
+
+#[bluejay_typegen::typegen([
+    scalar MyScalar
+
+    type Query {
+        myField: MyScalar!
+    }
+])]
+pub mod schema {
+    type MyScalar = String;
+
+    #[query([
+        query MyQuery {
+            myField
+            myAliasedField: myField
+            myOtherAliasedField: myField
+        }
+    ], custom_scalar_overrides = {
+        "MyQuery.myField" => super::MyScalarOverride,
+        "MyQuery.myAliasedField" => ::std::primitive::i32,
+        "MyQuery.myOtherAliasedField" => (),
+    })]
+    pub mod query {}
+}
+
+fn main() {
+    let _ = schema::query::MyQuery {
+        my_field: "hello".to_string(),
+        my_aliased_field: 1,
+        my_other_aliased_field: (),
+    };
+}

--- a/bluejay-validator/src/executable/document/path.rs
+++ b/bluejay-validator/src/executable/document/path.rs
@@ -1,4 +1,7 @@
-use bluejay_core::{executable::ExecutableDocument, Indexable};
+use bluejay_core::{
+    executable::{ExecutableDocument, FragmentDefinition, OperationDefinition},
+    Indexable,
+};
 use std::cmp::{Eq, Ord, Ordering, PartialEq, PartialOrd};
 use std::hash::{Hash, Hasher};
 
@@ -33,11 +36,24 @@ impl<'a, E: ExecutableDocument> Path<'a, E> {
         clone.members.push(selection);
         clone
     }
+
+    pub fn members(&self) -> &[&'a E::Selection] {
+        &self.members
+    }
 }
 
 pub enum PathRoot<'a, E: ExecutableDocument> {
     Operation(&'a E::OperationDefinition),
     Fragment(&'a E::FragmentDefinition),
+}
+
+impl<'a, E: ExecutableDocument + 'a> PathRoot<'a, E> {
+    pub fn name(&self) -> Option<&'a str> {
+        match self {
+            Self::Operation(o) => o.as_ref().name(),
+            Self::Fragment(f) => Some(f.name()),
+        }
+    }
 }
 
 impl<E: ExecutableDocument> Clone for PathRoot<'_, E> {


### PR DESCRIPTION
Make it possible to customize which Rust type is used for a custom scalar type at a given path in a query. See the docs in `bluejay-typegen-macro/src/lib.rs` for an explanation and `bluejay-typegen/examples/shopify_function.rs` for an example.

Also adds a new analyzer to return the list of paths where the return type is a custom scalar, so that we can return a useful error message if the user provides a custom scalar override that is not valid.