### PR TITLE
Add support for operation, variable and fragment descriptions

### DIFF
--- a/bluejay-core/src/executable/fragment_definition.rs
+++ b/bluejay-core/src/executable/fragment_definition.rs
@@ -5,6 +5,7 @@ pub trait FragmentDefinition: Indexable {
     type Directives: VariableDirectives;
     type SelectionSet: SelectionSet;
 
+    fn description(&self) -> Option<&str>;
     fn name(&self) -> &str;
     fn type_condition(&self) -> &str;
     fn directives(&self) -> Option<&Self::Directives>;

--- a/bluejay-core/src/executable/operation_definition.rs
+++ b/bluejay-core/src/executable/operation_definition.rs
@@ -15,6 +15,13 @@ impl<'a, O: OperationDefinition> OperationDefinitionReference<'a, O> {
         }
     }
 
+    pub fn description(&self) -> Option<&str> {
+        match self {
+            Self::Explicit(eod) => eod.description(),
+            Self::Implicit(_) => None,
+        }
+    }
+
     pub fn name(&self) -> Option<&'a str> {
         match self {
             Self::Explicit(eod) => eod.name(),
@@ -56,6 +63,7 @@ pub trait ExplicitOperationDefinition {
     type Directives: VariableDirectives;
     type SelectionSet: SelectionSet;
 
+    fn description(&self) -> Option<&str>;
     fn operation_type(&self) -> OperationType;
     fn name(&self) -> Option<&str>;
     fn variable_definitions(&self) -> Option<&Self::VariableDefinitions>;

--- a/bluejay-core/src/executable/variable_definition.rs
+++ b/bluejay-core/src/executable/variable_definition.rs
@@ -6,6 +6,7 @@ pub trait VariableDefinition {
     type Directives: ConstDirectives;
     type Value: ConstValue;
 
+    fn description(&self) -> Option<&str>;
     fn variable(&self) -> &str;
     fn r#type(&self) -> &Self::VariableType;
     fn directives(&self) -> Option<&Self::Directives>;

--- a/bluejay-parser/src/ast/executable/operation_definition.rs
+++ b/bluejay-parser/src/ast/executable/operation_definition.rs
@@ -3,7 +3,7 @@ use crate::ast::{
     DepthLimiter, FromTokens, IsMatch, OperationType, ParseError, Tokens, TryFromTokens,
     VariableDirectives,
 };
-use crate::lexical_token::Name;
+use crate::lexical_token::{Name, StringValue};
 use crate::{HasSpan, Span};
 use bluejay_core::{
     executable::{OperationDefinition as CoreOperationDefinition, OperationDefinitionReference},
@@ -51,6 +51,7 @@ impl<'a> FromTokens<'a> for OperationDefinition<'a> {
         tokens: &mut impl Tokens<'a>,
         depth_limiter: DepthLimiter,
     ) -> Result<Self, ParseError> {
+        let description = tokens.next_if_string_value();
         if let Some(operation_type) =
             OperationType::try_from_tokens(tokens, depth_limiter.bump()?).transpose()?
         {
@@ -60,8 +61,13 @@ impl<'a> FromTokens<'a> for OperationDefinition<'a> {
             let directives =
                 VariableDirectives::try_from_tokens(tokens, depth_limiter.bump()?).transpose()?;
             let selection_set = SelectionSet::from_tokens(tokens, depth_limiter.bump()?)?;
-            let span = operation_type.span().merge(selection_set.span());
+            let span = if let Some(desc) = &description {
+                desc.span().merge(selection_set.span())
+            } else {
+                operation_type.span().merge(selection_set.span())
+            };
             Ok(Self::Explicit(ExplicitOperationDefinition {
+                description,
                 operation_type,
                 name,
                 variable_definitions,
@@ -69,12 +75,16 @@ impl<'a> FromTokens<'a> for OperationDefinition<'a> {
                 selection_set,
                 span,
             }))
-        } else if let Some(selection_set) =
-            SelectionSet::try_from_tokens(tokens, depth_limiter.bump()?).transpose()?
-        {
-            Ok(Self::Implicit(ImplicitOperationDefinition {
-                selection_set,
-            }))
+        } else if description.is_none() {
+            if let Some(selection_set) =
+                SelectionSet::try_from_tokens(tokens, depth_limiter.bump()?).transpose()?
+            {
+                Ok(Self::Implicit(ImplicitOperationDefinition {
+                    selection_set,
+                }))
+            } else {
+                Err(tokens.unexpected_token())
+            }
         } else {
             Err(tokens.unexpected_token())
         }
@@ -84,7 +94,12 @@ impl<'a> FromTokens<'a> for OperationDefinition<'a> {
 impl<'a> IsMatch<'a> for OperationDefinition<'a> {
     #[inline]
     fn is_match(tokens: &mut impl Tokens<'a>) -> bool {
-        OperationType::is_match(tokens) || SelectionSet::is_match(tokens)
+        OperationType::is_match(tokens)
+            || SelectionSet::is_match(tokens)
+            || (tokens.peek_string_value(0)
+                && bluejay_core::OperationType::POSSIBLE_VALUES
+                    .iter()
+                    .any(|value| tokens.peek_name_matches(1, value)))
     }
 }
 
@@ -99,6 +114,7 @@ impl HasSpan for OperationDefinition<'_> {
 
 #[derive(Debug)]
 pub struct ExplicitOperationDefinition<'a> {
+    description: Option<StringValue<'a>>,
     operation_type: OperationType,
     name: Option<Name<'a>>,
     variable_definitions: Option<VariableDefinitions<'a>>,
@@ -111,6 +127,10 @@ impl<'a> bluejay_core::executable::ExplicitOperationDefinition for ExplicitOpera
     type VariableDefinitions = VariableDefinitions<'a>;
     type Directives = VariableDirectives<'a>;
     type SelectionSet = SelectionSet<'a>;
+
+    fn description(&self) -> Option<&str> {
+        self.description.as_ref().map(AsRef::as_ref)
+    }
 
     fn operation_type(&self) -> bluejay_core::OperationType {
         (&self.operation_type).into()

--- a/bluejay-parser/tests/snapshots/executable_document_integration_test__error@description_on_implicit_operation.graphql.snap
+++ b/bluejay-parser/tests/snapshots/executable_document_integration_test__error@description_on_implicit_operation.graphql.snap
@@ -1,0 +1,12 @@
+---
+source: bluejay-parser/tests/executable_document_integration_test.rs
+expression: formatted_errors
+input_file: bluejay-parser/tests/test_data/executable_document/error/description_on_implicit_operation.graphql
+---
+Error: Unexpected token
+   ╭─[ description_on_implicit_operation.graphql:1:1 ]
+   │
+ 1 │ "This description is invalid because implicit operations cannot have descriptions"
+   │ ─────────────────────────────────────────┬────────────────────────────────────────  
+   │                                          ╰────────────────────────────────────────── Unexpected token
+───╯

--- a/bluejay-parser/tests/test_data/executable_document/error/description_on_implicit_operation.graphql
+++ b/bluejay-parser/tests/test_data/executable_document/error/description_on_implicit_operation.graphql
@@ -1,0 +1,7 @@
+"This description is invalid because implicit operations cannot have descriptions"
+{
+  user {
+    id
+    name
+  }
+}

--- a/bluejay-parser/tests/test_data/executable_document/valid/fragment_with_description.graphql
+++ b/bluejay-parser/tests/test_data/executable_document/valid/fragment_with_description.graphql
@@ -1,0 +1,12 @@
+query GetUserWithFragment {
+  user {
+    ...UserFields
+  }
+}
+
+"This fragment contains common user fields"
+fragment UserFields on User {
+  id
+  name
+  email
+}

--- a/bluejay-parser/tests/test_data/executable_document/valid/mixed_descriptions.graphql
+++ b/bluejay-parser/tests/test_data/executable_document/valid/mixed_descriptions.graphql
@@ -1,0 +1,30 @@
+"Fetch user data with detailed information"
+query GetUserDetails(
+  "The user's unique identifier"
+  $userId: ID!
+  
+  "Include extended profile information"
+  $includeProfile: Boolean = false
+) {
+  user(id: $userId) {
+    ...BaseUserFields
+    
+    profile @include(if: $includeProfile) {
+      ...ProfileFields
+    }
+  }
+}
+
+"Basic user information fragment"
+fragment BaseUserFields on User {
+  id
+  name
+  email
+}
+
+"Extended profile information"  
+fragment ProfileFields on Profile {
+  bio
+  avatar
+  joinedDate
+}

--- a/bluejay-parser/tests/test_data/executable_document/valid/operation_with_description.graphql
+++ b/bluejay-parser/tests/test_data/executable_document/valid/operation_with_description.graphql
@@ -1,0 +1,23 @@
+"This is a query description"
+query GetUser {
+  user {
+    id
+    name
+  }
+}
+
+"This is a mutation description"
+mutation UpdateUser($id: ID!) {
+  updateUser(id: $id) {
+    id
+    name
+  }
+}
+
+"This is a subscription description"
+subscription OnUserUpdate {
+  userUpdated {
+    id
+    name
+  }
+}

--- a/bluejay-parser/tests/test_data/executable_document/valid/variable_with_description.graphql
+++ b/bluejay-parser/tests/test_data/executable_document/valid/variable_with_description.graphql
@@ -1,0 +1,30 @@
+query GetUserById(
+  "The user's unique identifier"
+  $id: ID!
+  
+  "Optional name filter"
+  $nameFilter: String
+) {
+  user(id: $id, nameFilter: $nameFilter) {
+    id
+    name
+    email
+  }
+}
+
+mutation UpdateUserInfo(
+  "User ID to update"
+  $userId: ID!
+  
+  "New name for the user"
+  $name: String!
+  
+  "Updated email address"
+  $email: String
+) {
+  updateUser(id: $userId, name: $name, email: $email) {
+    id
+    name
+    email
+  }
+}


### PR DESCRIPTION
Implements the new Executable document descriptions as specified in https://github.com/graphql/graphql-spec/pull/1170

