### PR TITLE
Update Rust toolchain to 1.95

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -10,6 +10,15 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
+  msrv:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Install Rust 1.88.0
+        run: rustup toolchain install 1.88.0 --profile minimal
+      - name: Check minimum Rust version
+        run: cargo +1.88.0 check --workspace --all-targets --all-features
+
   lint:
     runs-on: ubuntu-latest
     steps:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -163,7 +163,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 3.0.2",
- "unicode-segmentation",
 ]
 
 [[package]]
@@ -1156,9 +1155,9 @@ checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.12.0"
+version = "1.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
+checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
 
 [[package]]
 name = "unicode-width"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ resolver = "2"
 
 [workspace.package]
 version = "0.3.1"
+rust-version = "1.88"
 
 [workspace.lints.clippy]
 wildcard_imports = "deny"
@@ -26,7 +27,7 @@ bluejay-printer = { path = "./bluejay-printer", version = "=0.3.1" }
 bluejay-schema-comparator = { path = "./bluejay-schema-comparator", version = "=0.3.1" }
 bluejay-typegen = { path = "./bluejay-typegen", version = "=0.3.1" }
 bluejay-typegen-codegen = { path = "./bluejay-typegen-codegen", version = "=0.3.1" }
-bluejay-typegen-macro = { path = "./bluejay-typegen-macro", version = "=0.3.1" }
+bluejay-typegen-macro = { path = "./bluejay-typegen-macro", version = "=0.3.1", default-features = false }
 bluejay-validator = { path = "./bluejay-validator", version = "=0.3.1" }
 bluejay-operation-normalizer = { path = "./bluejay-operation-normalizer", version = "=0.3.1" }
 bluejay-visibility = { path = "./bluejay-visibility", version = "=0.3.1" }

--- a/bluejay-core/Cargo.toml
+++ b/bluejay-core/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "bluejay-core"
 version.workspace = true
+rust-version.workspace = true
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/Shopify/bluejay"

--- a/bluejay-core/src/definition/schema_definition.rs
+++ b/bluejay-core/src/definition/schema_definition.rs
@@ -102,7 +102,7 @@ pub trait SchemaDefinition:
     fn get_type_definition(
         &self,
         name: &str,
-    ) -> Option<TypeDefinitionReference<Self::TypeDefinition>>;
+    ) -> Option<TypeDefinitionReference<'_, Self::TypeDefinition>>;
     fn type_definitions(&self) -> Self::TypeDefinitions<'_>;
     fn get_directive_definition(&self, name: &str) -> Option<&Self::DirectiveDefinition>;
     fn directive_definitions(&self) -> Self::DirectiveDefinitions<'_>;

--- a/bluejay-operation-normalizer/Cargo.toml
+++ b/bluejay-operation-normalizer/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "bluejay-operation-normalizer"
 version.workspace = true
+rust-version.workspace = true
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/Shopify/bluejay"

--- a/bluejay-operation-normalizer/benches/normalize.rs
+++ b/bluejay-operation-normalizer/benches/normalize.rs
@@ -1,7 +1,7 @@
 use bluejay_parser::ast::{executable::ExecutableDocument, Parse};
 use criterion::{criterion_group, criterion_main, Criterion};
 
-fn parse(input: &str) -> ExecutableDocument {
+fn parse(input: &str) -> ExecutableDocument<'_> {
     ExecutableDocument::parse(input)
         .result
         .expect("parse error")

--- a/bluejay-operation-normalizer/src/lib.rs
+++ b/bluejay-operation-normalizer/src/lib.rs
@@ -22,54 +22,54 @@
 //!    each selection. This is a single bottom-up pass that builds and normalizes each level
 //!    before returning it to the parent:
 //!
-//!    a. **Fields** — collect the field name (dropping any alias), sorted argument names,
-//!       sorted directives, and recursively normalized child selections.
-//!       ```graphql
-//!       # input
-//!       { myAlias: field(z: 1, a: 2) }
-//!       # normalized
-//!       query{field(a:,z:)}
-//!       ```
+//!    - **Fields** — collect the field name (dropping any alias), sorted argument names,
+//!      sorted directives, and recursively normalized child selections.
+//!      ```graphql
+//!      # input
+//!      { myAlias: field(z: 1, a: 2) }
+//!      # normalized
+//!      query{field(a:,z:)}
+//!      ```
 //!
-//!    b. **Fragment spreads** — expand inline: replace `...FragName` with
-//!       `... on <TypeCondition> { <selections> }`, merging directives from both the spread
-//!       and the fragment definition. Unused fragments are naturally excluded. Cycles are
-//!       detected via a stack of currently-expanding fragment names.
-//!       ```graphql
-//!       # input
-//!       { ...F }
-//!       fragment F on User { name }
-//!       # normalized — spread replaced with inline fragment, named fragment dropped
-//!       query{...on User{name}}
-//!       ```
+//!    - **Fragment spreads** — expand inline: replace `...FragName` with
+//!      `... on <TypeCondition> { <selections> }`, merging directives from both the spread
+//!      and the fragment definition. Unused fragments are naturally excluded. Cycles are
+//!      detected via a stack of currently-expanding fragment names.
+//!      ```graphql
+//!      # input
+//!      { ...F }
+//!      fragment F on User { name }
+//!      # normalized — spread replaced with inline fragment, named fragment dropped
+//!      query{...on User{name}}
+//!      ```
 //!
-//!    c. **Inline fragments** — if bare (no type condition, no directives), flatten their
-//!       children directly into the parent selection set. Otherwise, keep as-is.
-//!       ```graphql
-//!       # input — bare inline fragment (no type condition, no directives)
-//!       { ... { name email } }
-//!       # normalized — children flattened into parent
-//!       query{email name}
-//!       ```
+//!    - **Inline fragments** — if bare (no type condition, no directives), flatten their
+//!      children directly into the parent selection set. Otherwise, keep as-is.
+//!      ```graphql
+//!      # input — bare inline fragment (no type condition, no directives)
+//!      { ... { name email } }
+//!      # normalized — children flattened into parent
+//!      query{email name}
+//!      ```
 //!
-//!    d. **Merge inline fragments** — at each level, merge inline fragments that share the
-//!       same `(type_condition, directives)` pair into a single inline fragment, combining
-//!       their child selections.
-//!       ```graphql
-//!       # input — two inline fragments on same type
-//!       { ... on User { name } ... on User { email } }
-//!       # normalized — merged into one
-//!       query{...on User{email name}}
-//!       ```
+//!    - **Merge inline fragments** — at each level, merge inline fragments that share the
+//!      same `(type_condition, directives)` pair into a single inline fragment, combining
+//!      their child selections.
+//!      ```graphql
+//!      # input — two inline fragments on same type
+//!      { ... on User { name } ... on User { email } }
+//!      # normalized — merged into one
+//!      query{...on User{email name}}
+//!      ```
 //!
-//!    e. **Sort selections** — fields first (alphabetically by field name), then inline
-//!       fragments (by type condition, then by directives).
-//!       ```graphql
-//!       # input
-//!       { z a ... on User { b } m }
-//!       # normalized — fields sorted first, then inline fragments
-//!       query{a m z ...on User{b}}
-//!       ```
+//!    - **Sort selections** — fields first (alphabetically by field name), then inline
+//!      fragments (by type condition, then by directives).
+//!      ```graphql
+//!      # input
+//!      { z a ... on User { b } m }
+//!      # normalized — fields sorted first, then inline fragments
+//!      query{a m z ...on User{b}}
+//!      ```
 //!
 //! 3. **Serialize** the normalized IR to a compact canonical string:
 //!    - Operation type keyword (`query`, `mutation`, `subscription`) with no name.
@@ -147,7 +147,7 @@ mod tests {
     use super::*;
     use bluejay_parser::ast::{executable::ExecutableDocument as ParserDoc, Parse};
 
-    fn parse(input: &str) -> ParserDoc {
+    fn parse(input: &str) -> ParserDoc<'_> {
         ParserDoc::parse(input).result.expect("parse error")
     }
 

--- a/bluejay-parser/Cargo.toml
+++ b/bluejay-parser/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "bluejay-parser"
 version.workspace = true
+rust-version.workspace = true
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/Shopify/bluejay"

--- a/bluejay-parser/src/ast/definition/explicit_schema_definition.rs
+++ b/bluejay-parser/src/ast/definition/explicit_schema_definition.rs
@@ -19,7 +19,7 @@ pub struct ExplicitSchemaDefinition<'a, C: Context> {
 impl<'a, C: Context> ExplicitSchemaDefinition<'a, C> {
     pub(crate) const SCHEMA_IDENTIFIER: &'static str = "schema";
 
-    pub(crate) fn description(&self) -> Option<&StringValue> {
+    pub(crate) fn description(&self) -> Option<&StringValue<'_>> {
         self.description.as_ref()
     }
 

--- a/bluejay-parser/src/ast/executable/field.rs
+++ b/bluejay-parser/src/ast/executable/field.rs
@@ -96,11 +96,11 @@ impl<'a> Field<'a> {
         &self.name
     }
 
-    pub fn arguments(&self) -> Option<&VariableArguments> {
+    pub fn arguments(&self) -> Option<&VariableArguments<'_>> {
         self.arguments.as_ref()
     }
 
-    pub fn selection_set(&self) -> Option<&SelectionSet> {
+    pub fn selection_set(&self) -> Option<&SelectionSet<'_>> {
         self.selection_set.as_ref()
     }
 }

--- a/bluejay-parser/src/ast/executable/fragment_definition.rs
+++ b/bluejay-parser/src/ast/executable/fragment_definition.rs
@@ -63,7 +63,7 @@ impl<'a> FragmentDefinition<'a> {
         &self.type_condition
     }
 
-    pub fn selection_set(&self) -> &SelectionSet {
+    pub fn selection_set(&self) -> &SelectionSet<'_> {
         &self.selection_set
     }
 }

--- a/bluejay-parser/src/ast/executable/type_condition.rs
+++ b/bluejay-parser/src/ast/executable/type_condition.rs
@@ -25,7 +25,7 @@ impl<'a> IsMatch<'a> for TypeCondition<'a> {
 impl TypeCondition<'_> {
     pub(crate) const ON: &'static str = "on";
 
-    pub fn named_type(&self) -> &Name {
+    pub fn named_type(&self) -> &Name<'_> {
         &self.named_type
     }
 }

--- a/bluejay-parser/src/ast/executable/variable_definition.rs
+++ b/bluejay-parser/src/ast/executable/variable_definition.rs
@@ -42,15 +42,15 @@ impl<'a> FromTokens<'a> for VariableDefinition<'a> {
 }
 
 impl VariableDefinition<'_> {
-    pub fn variable(&self) -> &Variable {
+    pub fn variable(&self) -> &Variable<'_> {
         &self.variable
     }
 
-    pub fn r#type(&self) -> &VariableType {
+    pub fn r#type(&self) -> &VariableType<'_> {
         &self.r#type
     }
 
-    pub fn default_value(&self) -> Option<&ConstValue> {
+    pub fn default_value(&self) -> Option<&ConstValue<'_>> {
         self.default_value.as_ref()
     }
 }

--- a/bluejay-parser/src/ast/tokens.rs
+++ b/bluejay-parser/src/ast/tokens.rs
@@ -20,7 +20,7 @@ pub trait Tokens<'a>: Iterator<Item = LexicalToken<'a>> {
     fn next_if_name(&mut self) -> Option<Name<'a>>;
     fn next_if_name_matches(&mut self, name: &str) -> Option<Span>;
     fn peek_variable_name(&mut self, n: usize) -> bool;
-    fn peek_name(&mut self, n: usize) -> Option<&Name>;
+    fn peek_name(&mut self, n: usize) -> Option<&Name<'_>>;
     fn peek_name_matches(&mut self, n: usize, name: &str) -> bool;
     fn peek_string_value(&mut self, n: usize) -> bool;
     fn peek_punctuator_matches(&mut self, n: usize, punctuator_type: PunctuatorType) -> bool;
@@ -56,7 +56,7 @@ impl<'a, T: Lexer<'a>> LexerTokens<'a, T> {
     }
 
     #[inline]
-    pub fn peek_next(&mut self) -> Option<&LexicalToken> {
+    pub fn peek_next(&mut self) -> Option<&LexicalToken<'_>> {
         self.peek(0)
     }
 
@@ -201,7 +201,7 @@ impl<'a, T: Lexer<'a>> LexerTokens<'a, T> {
     }
 
     #[inline]
-    pub fn peek_name(&mut self, n: usize) -> Option<&Name> {
+    pub fn peek_name(&mut self, n: usize) -> Option<&Name<'_>> {
         self.peek(n).and_then(LexicalToken::as_name)
     }
 
@@ -304,7 +304,7 @@ impl<'a, T: Lexer<'a>> Tokens<'a> for LexerTokens<'a, T> {
     }
 
     #[inline]
-    fn peek_name(&mut self, n: usize) -> Option<&Name> {
+    fn peek_name(&mut self, n: usize) -> Option<&Name<'_>> {
         self.peek_name(n)
     }
 

--- a/bluejay-parser/src/lexer/logos_lexer/block_string_lexer.rs
+++ b/bluejay-parser/src/lexer/logos_lexer/block_string_lexer.rs
@@ -104,7 +104,7 @@ impl Token {
         let common_indent = lines[1..]
             .iter()
             .filter_map(|&(start, end)| {
-                let line_bytes = raw[start..end].as_bytes();
+                let line_bytes = &raw.as_bytes()[start..end];
                 let indent = line_bytes.iter().position(|&b| b != b' ' && b != b'\t');
                 indent // None means all-whitespace, filtered out
             })

--- a/bluejay-printer/Cargo.toml
+++ b/bluejay-printer/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "bluejay-printer"
 version.workspace = true
+rust-version.workspace = true
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/Shopify/bluejay"

--- a/bluejay-schema-comparator/Cargo.toml
+++ b/bluejay-schema-comparator/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "bluejay-schema-comparator"
 version.workspace = true
+rust-version.workspace = true
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/Shopify/bluejay"

--- a/bluejay-schema-comparator/src/diff/directive_definition_argument.rs
+++ b/bluejay-schema-comparator/src/diff/directive_definition_argument.rs
@@ -49,14 +49,14 @@ impl<'a, S: SchemaDefinition + 'a> DirectiveDefinitionArgumentDiff<'a, S> {
             self.old_argument_definition.default_value(),
             self.new_argument_definition.default_value(),
         ) {
-            (Some(old_default), Some(new_default)) => {
-                if old_default.as_ref() != new_default.as_ref() {
-                    changes.push(Change::DirectiveDefinitionArgumentDefaultValueChanged {
-                        directive_definition: self.directive_definition,
-                        old_argument_definition: self.old_argument_definition,
-                        new_argument_definition: self.new_argument_definition,
-                    });
-                }
+            (Some(old_default), Some(new_default))
+                if old_default.as_ref() != new_default.as_ref() =>
+            {
+                changes.push(Change::DirectiveDefinitionArgumentDefaultValueChanged {
+                    directive_definition: self.directive_definition,
+                    old_argument_definition: self.old_argument_definition,
+                    new_argument_definition: self.new_argument_definition,
+                });
             }
             (Some(_), None) | (None, Some(_)) => {
                 changes.push(Change::DirectiveDefinitionArgumentDefaultValueChanged {

--- a/bluejay-typegen-codegen/Cargo.toml
+++ b/bluejay-typegen-codegen/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "bluejay-typegen-codegen"
 version.workspace = true
+rust-version.workspace = true
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/Shopify/bluejay"
@@ -17,8 +18,6 @@ syn = { version = "3.0", features = ["full"] }
 quote = "1.0"
 proc-macro2 = "1.0"
 convert_case = "0.10"
-# Pin: v1.13+ requires Rust 1.86+. Remove once toolchain is upgraded.
-unicode-segmentation = ">=1.11, <1.13"
 itertools = "0.15.0"
 
 [lints]

--- a/bluejay-typegen-codegen/src/input_object_type_definition.rs
+++ b/bluejay-typegen-codegen/src/input_object_type_definition.rs
@@ -184,18 +184,14 @@ impl<'a, S: SchemaDefinition, C: CodeGenerator> InputObjectTypeDefinitionBuilder
         match ty {
             InputTypeReference::Base(base, _) if base.name() == target => true,
             ty => match ty.base(self.config.schema_definition()) {
-                BaseInputTypeReference::InputObject(iotd) => {
-                    if visited.insert(iotd.name()) {
-                        iotd.input_field_definitions().iter().any(|ivd| {
-                            self.contains_non_list_reference(
-                                target,
-                                ivd.r#type().as_ref(self.config.schema_definition()),
-                                visited,
-                            )
-                        })
-                    } else {
-                        false
-                    }
+                BaseInputTypeReference::InputObject(iotd) if visited.insert(iotd.name()) => {
+                    iotd.input_field_definitions().iter().any(|ivd| {
+                        self.contains_non_list_reference(
+                            target,
+                            ivd.r#type().as_ref(self.config.schema_definition()),
+                            visited,
+                        )
+                    })
                 }
                 _ => false,
             },

--- a/bluejay-typegen-macro/Cargo.toml
+++ b/bluejay-typegen-macro/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "bluejay-typegen-macro"
 version.workspace = true
+rust-version.workspace = true
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/Shopify/bluejay"

--- a/bluejay-typegen/Cargo.toml
+++ b/bluejay-typegen/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "bluejay-typegen"
 version.workspace = true
+rust-version.workspace = true
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/Shopify/bluejay"

--- a/bluejay-typegen/tests/validation_cases/error/fragment_and_operation_name_clash.stderr
+++ b/bluejay-typegen/tests/validation_cases/error/fragment_and_operation_name_clash.stderr
@@ -7,6 +7,7 @@ error: Error: typegen requires fragment and operation names to be unique, but en
           │                                                 │
           │                                                 ╰───────────────── Fragment definition name collides with operation definition name
        ───╯
+
   --> tests/validation_cases/error/fragment_and_operation_name_clash.rs:11:13
    |
 11 |       #[query([

--- a/bluejay-typegen/tests/validation_cases/error/interface_fragment_spread_invalid_target.stderr
+++ b/bluejay-typegen/tests/validation_cases/error/interface_fragment_spread_invalid_target.stderr
@@ -5,6 +5,7 @@ error: Error: typegen requires fragment spreads on interfaces to target either t
           │                 ──────┬──────
           │                       ╰──────── Fragment spread on interface type
        ───╯
+
   --> tests/validation_cases/error/interface_fragment_spread_invalid_target.rs:15:13
    |
 15 |       #[query([

--- a/bluejay-typegen/tests/validation_cases/error/invalid_query.stderr
+++ b/bluejay-typegen/tests/validation_cases/error/invalid_query.stderr
@@ -5,12 +5,13 @@ error: Error: Field `bar` does not exist on type `Query`
           │   ─┬─
           │    ╰─── Field does not exist on type `Query`
        ───╯
+
   --> tests/validation_cases/error/invalid_query.rs:7:13
    |
-7  |       #[query([
+ 7 |       #[query([
    |  _____________^
-8  | |         {
-9  | |             bar
+ 8 | |         {
+ 9 | |             bar
 10 | |         }
 11 | |     ])]
    | |_____^

--- a/bluejay-typegen/tests/validation_cases/error/invalid_query_fragment_and_field_selections.stderr
+++ b/bluejay-typegen/tests/validation_cases/error/invalid_query_fragment_and_field_selections.stderr
@@ -7,12 +7,13 @@ error: Error: typegen requires a fragment spread to be the only selection in the
           │             │
           │             ╰────────── Fragment spread
        ───╯
+
   --> tests/validation_cases/error/invalid_query_fragment_and_field_selections.rs:7:13
    |
-7  |       #[query([
+ 7 |       #[query([
    |  _____________^
-8  | |         {
-9  | |             foo
+ 8 | |         {
+ 9 | |             foo
 10 | |             ...MyFragment
 ...  |
 16 | |     ])]

--- a/bluejay-typegen/tests/validation_cases/error/invalid_query_missing_typename_on_union.stderr
+++ b/bluejay-typegen/tests/validation_cases/error/invalid_query_missing_typename_on_union.stderr
@@ -5,6 +5,7 @@ error: Error: typegen requires unaliased selection of `__typename` on union type
           │       ───────────────────┬───────────────────
           │                          ╰───────────────────── Selection set does not contain an unaliased `__typename` selection as the first selection
        ───╯
+
   --> tests/validation_cases/error/invalid_query_missing_typename_on_union.rs:17:13
    |
 17 |       #[query([

--- a/bluejay-typegen/tests/validation_cases/error/invalid_query_typename_not_first_selection_on_union.stderr
+++ b/bluejay-typegen/tests/validation_cases/error/invalid_query_typename_not_first_selection_on_union.stderr
@@ -13,6 +13,7 @@ error: Error: typegen requires unaliased selection of `__typename` on union type
           │                           ─────┬────
           │                                ╰────── Field selection on union type
        ───╯
+
   --> tests/validation_cases/error/invalid_query_typename_not_first_selection_on_union.rs:17:13
    |
 17 |       #[query([

--- a/bluejay-typegen/tests/validation_cases/error/invalid_schema.stderr
+++ b/bluejay-typegen/tests/validation_cases/error/invalid_schema.stderr
@@ -5,6 +5,7 @@ error: Error: Referenced type `Bar` does not exist
           │                   ─┬─
           │                    ╰─── No definition for referenced type
        ───╯
+
  --> tests/validation_cases/error/invalid_schema.rs:1:28
   |
 1 |   #[bluejay_typegen::typegen([

--- a/bluejay-typegen/tests/validation_cases/error/union_multiple_inline_fragments_for_same_type.stderr
+++ b/bluejay-typegen/tests/validation_cases/error/union_multiple_inline_fragments_for_same_type.stderr
@@ -9,6 +9,7 @@ error: Error: typegen requires the inline fragments in a selection set have uniq
           │                                              │
           │                                              ╰──────────── Inline fragment targeting Bar
        ───╯
+
   --> tests/validation_cases/error/union_multiple_inline_fragments_for_same_type.rs:17:13
    |
 17 |       #[query([

--- a/bluejay-validator/Cargo.toml
+++ b/bluejay-validator/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "bluejay-validator"
 version.workspace = true
+rust-version.workspace = true
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/Shopify/bluejay"

--- a/bluejay-validator/src/value/input_coercion.rs
+++ b/bluejay-validator/src/value/input_coercion.rs
@@ -282,7 +282,7 @@ fn coerce_input_object_value<
         errors.extend(
             indexed_object
                 .iter()
-                .filter(|(_, entries)| (entries.len() > 1))
+                .filter(|(_, entries)| entries.len() > 1)
                 .map(|(&field_name, entries)| Error::NonUniqueFieldNames {
                     value,
                     field_name,

--- a/bluejay-visibility/Cargo.toml
+++ b/bluejay-visibility/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "bluejay-visibility"
 version.workspace = true
+rust-version.workspace = true
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/Shopify/bluejay"

--- a/bluejay-visibility/src/schema_definition.rs
+++ b/bluejay-visibility/src/schema_definition.rs
@@ -201,7 +201,7 @@ impl<'a, S: definition::SchemaDefinition + 'a, W: Warden<SchemaDefinition = S>>
     fn get_type_definition(
         &self,
         name: &str,
-    ) -> Option<definition::TypeDefinitionReference<Self::TypeDefinition>> {
+    ) -> Option<definition::TypeDefinitionReference<'_, Self::TypeDefinition>> {
         self.cache
             .get_type_definition(name)
             .or_else(|| {

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.85.1"
+channel = "1.95.0"
 targets = ["wasm32-wasip1"]


### PR DESCRIPTION
## Summary

- This change updates the development toolchain to Rust 1.95.0.
- All published crates declare Rust 1.88 as the minimum supported Rust version.
- CI checks all targets and features with Rust 1.88.0.
- The code fixes the compiler and Clippy warnings from Rust 1.95.
- The dependency update removes the obsolete `unicode-segmentation` version limit.
- The diagnostic snapshots include the Rust 1.95 output format.
- This change does not update `trybuild`.

## Verification

- `cargo +1.88.0 check --workspace --all-targets --all-features`
- `cargo fmt --all --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-features`
- `cargo build --release --all-features`
- `cargo build --release --examples --all-features`
- `cargo build --profile shopify-function --target wasm32-wasip1 --example shopify_function -p bluejay-typegen`
