### PR TITLE
v0.4.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -79,7 +79,7 @@ dependencies = [
 
 [[package]]
 name = "bluejay-core"
-version = "0.3.1"
+version = "0.4.0"
 dependencies = [
  "enum-as-inner",
  "itertools 0.15.0",
@@ -89,7 +89,7 @@ dependencies = [
 
 [[package]]
 name = "bluejay-operation-normalizer"
-version = "0.3.1"
+version = "0.4.0"
 dependencies = [
  "blake3",
  "bluejay-core",
@@ -100,7 +100,7 @@ dependencies = [
 
 [[package]]
 name = "bluejay-parser"
-version = "0.3.1"
+version = "0.4.0"
 dependencies = [
  "ariadne",
  "bluejay-core",
@@ -116,7 +116,7 @@ dependencies = [
 
 [[package]]
 name = "bluejay-printer"
-version = "0.3.1"
+version = "0.4.0"
 dependencies = [
  "bluejay-core",
  "bluejay-parser",
@@ -126,7 +126,7 @@ dependencies = [
 
 [[package]]
 name = "bluejay-schema-comparator"
-version = "0.3.1"
+version = "0.4.0"
 dependencies = [
  "bluejay-core",
  "bluejay-parser",
@@ -137,7 +137,7 @@ dependencies = [
 
 [[package]]
 name = "bluejay-typegen"
-version = "0.3.1"
+version = "0.4.0"
 dependencies = [
  "bluejay-typegen-macro",
  "serde",
@@ -147,7 +147,7 @@ dependencies = [
 
 [[package]]
 name = "bluejay-typegen-codegen"
-version = "0.3.1"
+version = "0.4.0"
 dependencies = [
  "bluejay-core",
  "bluejay-parser",
@@ -161,7 +161,7 @@ dependencies = [
 
 [[package]]
 name = "bluejay-typegen-macro"
-version = "0.3.1"
+version = "0.4.0"
 dependencies = [
  "bluejay-core",
  "bluejay-typegen-codegen",
@@ -172,7 +172,7 @@ dependencies = [
 
 [[package]]
 name = "bluejay-validator"
-version = "0.3.1"
+version = "0.4.0"
 dependencies = [
  "bluejay-core",
  "bluejay-parser",
@@ -187,7 +187,7 @@ dependencies = [
 
 [[package]]
 name = "bluejay-visibility"
-version = "0.3.1"
+version = "0.4.0"
 dependencies = [
  "bluejay-core",
  "bluejay-parser",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,23 +14,23 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.3.1"
+version = "0.4.0"
 rust-version = "1.88"
 
 [workspace.lints.clippy]
 wildcard_imports = "deny"
 
 [workspace.dependencies]
-bluejay-core = { path = "./bluejay-core", version = "=0.3.1" }
-bluejay-parser = { path = "./bluejay-parser", version = "=0.3.1" }
-bluejay-printer = { path = "./bluejay-printer", version = "=0.3.1" }
-bluejay-schema-comparator = { path = "./bluejay-schema-comparator", version = "=0.3.1" }
-bluejay-typegen = { path = "./bluejay-typegen", version = "=0.3.1" }
-bluejay-typegen-codegen = { path = "./bluejay-typegen-codegen", version = "=0.3.1" }
-bluejay-typegen-macro = { path = "./bluejay-typegen-macro", version = "=0.3.1", default-features = false }
-bluejay-validator = { path = "./bluejay-validator", version = "=0.3.1" }
-bluejay-operation-normalizer = { path = "./bluejay-operation-normalizer", version = "=0.3.1" }
-bluejay-visibility = { path = "./bluejay-visibility", version = "=0.3.1" }
+bluejay-core = { path = "./bluejay-core", version = "=0.4.0" }
+bluejay-parser = { path = "./bluejay-parser", version = "=0.4.0" }
+bluejay-printer = { path = "./bluejay-printer", version = "=0.4.0" }
+bluejay-schema-comparator = { path = "./bluejay-schema-comparator", version = "=0.4.0" }
+bluejay-typegen = { path = "./bluejay-typegen", version = "=0.4.0" }
+bluejay-typegen-codegen = { path = "./bluejay-typegen-codegen", version = "=0.4.0" }
+bluejay-typegen-macro = { path = "./bluejay-typegen-macro", version = "=0.4.0", default-features = false }
+bluejay-validator = { path = "./bluejay-validator", version = "=0.4.0" }
+bluejay-operation-normalizer = { path = "./bluejay-operation-normalizer", version = "=0.4.0" }
+bluejay-visibility = { path = "./bluejay-visibility", version = "=0.4.0" }
 
 [profile.shopify-function]
 inherits = "release"


### PR DESCRIPTION
Release a new version with:
- MSRV of `1.88`
- `syn` bump to `3.0`
- `logos` bump to `0.16`
- many performance improvements