### PR TITLE
Replace paste with pastey

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -180,7 +180,7 @@ dependencies = [
  "insta",
  "itertools 0.15.0",
  "once_cell",
- "paste",
+ "pastey",
  "seq-macro",
  "serde_json",
 ]
@@ -737,10 +737,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
-name = "paste"
-version = "1.0.15"
+name = "pastey"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+checksum = "2ee67f1008b1ba2321834326597b8e186293b049a023cdef258527550b9935b4"
 
 [[package]]
 name = "plotters"

--- a/bluejay-validator/Cargo.toml
+++ b/bluejay-validator/Cargo.toml
@@ -13,7 +13,7 @@ description = "A GraphQL validator"
 [dependencies]
 bluejay-core = { workspace = true }
 bluejay-parser = { workspace = true, optional = true, features = ["format-errors"] }
-paste = "1.0"
+pastey = "0.2"
 itertools = "0.15.0"
 serde_json = { version = "1.0", optional = true }
 seq-macro = "0.3.5"

--- a/bluejay-validator/src/definition/rules.rs
+++ b/bluejay-validator/src/definition/rules.rs
@@ -9,7 +9,7 @@ pub use input_object_circular_references::InputObjectCircularReferences;
 #[macro_export]
 macro_rules! combine_definition_rules {
     ( $name:ty, $err:ty, [$( $rule:ty ),* $(,)?] $(,)? ) => {
-        paste::paste! {
+        pastey::paste! {
             pub struct $name<'a, S: bluejay_core::definition::SchemaDefinition> {
                 $([<$rule:snake>]: $rule<'a, S>,)*
             }


### PR DESCRIPTION
According to [RUSTSEC-2024-0436], the `paste` crate is no longer maintained, and `pastey` is suggested as a drop-in replacement.

[RUSTSEC-2024-0436]: https://rustsec.org/advisories/RUSTSEC-2024-0436

Closes #134

## Test plan

Ran the following at the workspace root:

```
$ cargo fmt
$ cargo clippy -- -D warnings
$ cargo nextest run
```